### PR TITLE
WebSocket keepAlive & client WebSocket protocol detection

### DIFF
--- a/static/client.js
+++ b/static/client.js
@@ -22,8 +22,12 @@ limitations under the License.
 			throw "Error: No webstrate ID provided.";
 		}
 
+		// Determine websocket protocol based on http/https protocol.
+		var protocol = location.protocol;
+		var wsProtocol = protocol === 'http:' ? 'ws:' : 'wss:';
+
 		// Establish a WebSocket connection to the server to be used by Webstrates.
-		var websocket = new ReconnectingWebSocket(`wss://${location.host}/ws/`);
+		var websocket = new ReconnectingWebSocket(`${wsProtocol}//${location.host}/ws/`);
 
 		// Set up a webstrate.
 		window.webstrate = new webstrates.Webstrate(websocket, webstrateId);

--- a/static/client.js
+++ b/static/client.js
@@ -23,7 +23,7 @@ limitations under the License.
 		}
 
 		// Establish a WebSocket connection to the server to be used by Webstrates.
-		var websocket = new ReconnectingWebSocket(`ws://${location.host}/ws/`);
+		var websocket = new ReconnectingWebSocket(`wss://${location.host}/ws/`);
 
 		// Set up a webstrate.
 		window.webstrate = new webstrates.Webstrate(websocket, webstrateId);

--- a/webstrates.js
+++ b/webstrates.js
@@ -346,8 +346,14 @@ wss.on('connection', function(client) {
 	var socketId = clientManager.addClient(client);
 
 	client.on('message', function(data) {
-		// Adding socketId to every incoming message
 		data = JSON.parse(data);
+
+		// ignore alive messages
+		if (data.type && data.type === 'alive') {
+			return;
+		}
+
+		// Adding socketId to every incoming message
 		data.socketId = socketId;
 		return stream.push(JSON.stringify(data));
 	});


### PR DESCRIPTION
- Implemented keepAlive interval on client to keep WebSocket connection between server and client alive. Current keepAlive implementation sends an alive message every 10s to the server.

- Client-side detection of WebSocket protocol based on http/https protocol (reading protocol from `location.protocol` property).