### PR TITLE
Server could crash on client connection drop + removed attribute "diffing"

### DIFF
--- a/client/webstrates/cookies.js
+++ b/client/webstrates/cookies.js
@@ -18,7 +18,7 @@ function updateCookie(key, value, isAnywhere = false) {
 		update: { key, value }
 	};
 	if (!isAnywhere) {
-		updateObj.d = globalObject.webstrateObject.webstrateId;
+		updateObj.d = globalObject.publicObject.webstrateId;
 	}
 	websocket.send(updateObj);
 }

--- a/client/webstrates/coreOpCreator.js
+++ b/client/webstrates/coreOpCreator.js
@@ -106,16 +106,16 @@ function attributeMutation(mutation, targetPathNode) {
 	// We are lose about checking jsonmlAttrs[mutation.attributeName], because we don't want to
 	// diff, regardless of whether it's an empty string or it's null.
 	// Also, if the newValue is short, it's easier and faster to just send it rather than patch it.
-	if (oldValue === null || newValue.length < 50 || !jsonmlAttrs[mutation.attributeName]) {
+	// if (oldValue === null || newValue.length < 50 || !jsonmlAttrs[mutation.attributeName]) {
 		coreEvents.triggerEvent('DOMAttributeSet', mutation.target, mutation.attributeName, oldValue,
 			newValue, true);
 		return [{ oi: newValue, p: path }];
-	}
+	// }
 
-	coreEvents.triggerEvent('DOMAttributeSet', mutation.target, mutation.attributeName, oldValue,
-		newValue, true);
-	let ops = patchesToOps(path, jsonmlAttrs[mutation.attributeName], newValue);
-	return ops;
+	// coreEvents.triggerEvent('DOMAttributeSet', mutation.target, mutation.attributeName, oldValue,
+	// 	newValue, true);
+	// let ops = patchesToOps(path, jsonmlAttrs[mutation.attributeName], newValue);
+	// return ops;
 }
 
 /**

--- a/helpers/ClientManager.js
+++ b/helpers/ClientManager.js
@@ -304,7 +304,7 @@ module.exports = function(messagingManager, db, pubsub) {
 	 */
 	module.subscribe = function(socketId, webstrateId, nodeId, retry = 5) {
 		// Make sure the client is connected to the webstrate.
-		if (!clients[socketId].webstrates[webstrateId]) {
+		if (!clients[socketId] || !clients[socketId].webstrates[webstrateId]) {
 			// The user may have been so eager to subscribe that they sent the command before they have
 			// joined the document. Let's retry the subscribe command in a little while.
 			if (retry > 0) {


### PR DESCRIPTION
The attribute diffing was commented out because it could result in inconsistent attribute values.

Added check to fix server crashing when subscription to a document happens after client lost socket connection with the server

Fixed "here" cookies, which was using webstrateObject instead of publicObject


