### PR TITLE
Removed type check for script elements in coreJsonML.toHTML, which pr…

### DIFF
--- a/client/webstrates/coreJsonML.js
+++ b/client/webstrates/coreJsonML.js
@@ -91,11 +91,8 @@ function toHTML(elem, xmlNs, scripts) {
 					selector.setAttribute(coreUtils.unescapeDots(index), value);
 				}
 
-				// Add scripts to our scripts list, so we can execute them later synchronously. Only add
-				// JavaScripts, i.e. scripts either without a type attribute, or with 'text/javascript' as
-				// the type attribute.
-				if (selector.tagName.toLowerCase() === 'script' && (!selector.getAttribute('type') ||
-					selector.getAttribute('type') === 'text/javascript')) {
+				// Add scripts to our scripts list, so we can execute them later synchronously.
+				if (selector.tagName.toLowerCase() === 'script') {
 					selector.async = false;
 					scripts && scripts.push(selector);
 				}


### PR DESCRIPTION
…evented scripts other than <script> and <script type=“text/javascript”> from being executed. The fix allows to execute <script type=“module”> scripts in a webstrate. More information on the ES6 module type at https://developer.mozilla.org/en-US/docs/Web/HTML/Element/script and https://hacks.mozilla.org/2015/08/es6-in-depth-modules/