### PR TITLE
Reworked attribute approval in protected mode

### DIFF
--- a/client/webstrates/protectedMode.js
+++ b/client/webstrates/protectedMode.js
@@ -105,13 +105,13 @@ coreEvents.addEventListener('receivedDocument', (doc, options) => {
 					// Approve all children and their attributes.
 					// Combine approveNode and approveElementAttribute to avoid performing the
 					// recursiveForEach twice.
-					coreUtils.recursiveForEach(node, (descendant) => {
-						approveNode(descendant);
+					coreUtils.recursiveForEach(node, (childNode) => {
+						approveNode(childNode);
 
 						// Only an Element has attributes.
-						if (descendant instanceof Element) {
-							Array.from(descendant.attributes).forEach(attr => {
-								approveElementAttribute(descendant, attr.name);
+						if (childNode.nodeType === Node.ELEMENT_NODE) {
+							Array.from(childNode.attributes).forEach(attr => {
+								approveElementAttribute(childNode, attr.name);
 							});
 						}
 					});
@@ -151,7 +151,8 @@ coreEvents.addEventListener('receivedDocument', (doc, options) => {
 	 * Removes an attribute from the list of approved attributes making it transient.
 	 * 
 	 * @param {Element} element An element. 
-	 * @param {*} attrName Attribute name that will be removed from list of approved attribute names.
+	 * @param {String} attrName Attribute name that will be removed from list of approved attribute
+	 * names.
 	 */
 	const removeApproveElementAttribute = (element, attrName) => {
 		if (!element.__approvedAttributes) {
@@ -200,15 +201,22 @@ coreEvents.addEventListener('receivedDocument', (doc, options) => {
 		options = {}, ...unused) => {
 		const element = importNode(externalNode, deep, ...unused);
 		coreUtils.recursiveForEach(element, childNode => {
-			if (options && options.approved) approveNode(childNode);
+			if (options && options.approved) {
+				approveNode(childNode);
+				if (childNode.nodeType === Node.ELEMENT_NODE) {
+					Array.from(childNode.attributes).forEach(attr => {
+						approveElementAttribute(childNode, attr.name);
+					});
+				}
+			}
 			else childNode.nodeType === document.ELEMENT_NODE && childNode.setAttribute('unapproved', '');
 		});
 		return element;
 	});
 
 	// The elementOptions object should get passed into all prototype function calls (e.g.
-	// Element.setAttribute) made by other modules. This allows us to inject a setting on the object,
-	// so we can make all calls from other modules pre-approved.
+	// Element.setAttribute) made by other modules. This allows us to inject a setting on the
+	// object, so we can make all calls from other modules pre-approved.
 	coreDOM.elementOptions.approved = true;
 
 	const cloneNode = Node.prototype.cloneNode;
@@ -240,83 +248,162 @@ coreEvents.addEventListener('receivedDocument', (doc, options) => {
 		if (options && options.approved) removeApproveElementAttribute(this, name);
 	};
 
-	// Approve the 'class' attribute that will be added, e.g., when using
-	// Element.classList.{add,toggle,replace}.
-	const classListDescriptor = Object.getOwnPropertyDescriptor(Element.prototype, 'classList');
-	Object.defineProperty(Element.prototype, 'classList', {
-		set: function (value) {
-			return classListDescriptor.set.call(this, value);
-		},
-		get: function () {
-			const element = this;
-			const tokenList = classListDescriptor.get.call(element);
-
-			// This check is require to avoid constant reassignment of DOMTokenList.{add,toggle,replace},
-			// which ultimately will result in an "RangeError: Maximum call stack size exceeded" error.
-			if (tokenList && !tokenList.__hooked) {
-				// Override DOMTokenList.add
-				const add = tokenList.add;
-				tokenList.add = function (...tokens) {
-					if (element.__approved) approveElementAttribute(element, 'class');
-					return add.call(this, ...tokens);
-				};
-
-				// Override DOMTokenList.toggle
-				const toggle = tokenList.toggle;
-				tokenList.toggle = function (token, force, ...unused) {
-					if (element.__approved) approveElementAttribute(element, 'class');
-					return toggle.call(this, token, force, ...unused);
-				};
-
-				// Override DOMTokenList.replace
-				const replace = tokenList.replace;
-				tokenList.replace = function (oldToken, newToken, ...unused) {
-					if (element.__approved) approveElementAttribute(element, 'class');
-					return replace.call(this, oldToken, newToken, ...unused);
-				};
-
-				// Use defineProperty and enumerable false to disallow overriding it and
-				// hide it during enumeration.
-				Object.defineProperty(tokenList, '__hooked', {
-					get: () => { return true; },
-					enumerable: false
+	// Proxy all configurable properties with a set function to intercept calls to properties
+	// and approve their corresponding element attributes.
+	const proxyDescriptors = (prototype, properties) => {
+		properties.forEach(propertyName => {
+			const descriptor = Object.getOwnPropertyDescriptor(prototype, propertyName);
+			// Check if descriptor is configurable and has a set function already
+			if (descriptor.configurable && typeof descriptor.set === 'function') {
+				Object.defineProperty(prototype, propertyName, {
+					configurable: descriptor.configurable,
+					enumerable: descriptor.enumerable,
+					set: function (value) {
+						// The approved attributes need to be lower-case in order to be approved
+						// properly in the isTransientAttribute check.
+						if (this.__approved) approveElementAttribute(this, propertyName.toLowerCase());
+						return descriptor.set.call(this, value);
+					},
+					get: descriptor.get
 				});
 			}
+		});
+	};
 
-			return tokenList;
-		},
-		configurable: false
-	});
+	// Proxy Element.prototype and HTMLElement.prototype to approve attribute, e.g.,
+	// Element.prototype.id -> 'id' or HTMLElement.prototype.contentEditable -> 'contenteditable'.
+	proxyDescriptors(Element.prototype, ['id']);
+	proxyDescriptors(HTMLElement.prototype, ['accessKey', 'contentEditable', 'dir', 'draggable',
+		'hidden', 'lang', 'tabIndex', 'title', 'translate']);
 
-	// Approve the 'id' attribute that will be added when setting the Element.id property.
-	const idDescriptor = Object.getOwnPropertyDescriptor(Element.prototype, 'id');
-	Object.defineProperty(Element.prototype, 'id', {
-		set: function (value) {
-			if (this.__approved) approveElementAttribute(this, 'id');
-			return idDescriptor.set.call(this, value);
-		},
-		get: function () {
-			return idDescriptor.get.call(this);
-		},
-		configurable: false
-	});
+	// Convert Strings from camelCase to kebab-case.
+	const camelToKebab = (input) => {
+		return input.replace(/([a-z])([A-Z])/g, '$1-$2').toLowerCase();
+	};
 
-	// Approve the 'contenteditable' attribute that will be added when setting the
-	// HTMLElement.contentEditable property.
-	const contentEditableDescriptor = Object.getOwnPropertyDescriptor(HTMLElement.prototype,
-		'contentEditable');
-	Object.defineProperty(HTMLElement.prototype, 'contentEditable', {
-		set: function (value) {
-			// The approved attribute contentEditable has to be lower-case 'e' in order to be approved
-			// properly in the isTransientAttribute check.
-			if (this.__approved) approveElementAttribute(this, 'contenteditable');
-			return contentEditableDescriptor.set.call(this, value);
+	// Proxy definitions for 'classList', 'dataset', and 'style'.
+	const propertiesElement = [
+		{
+			propertyName: 'classList',
+			prototype: Element.prototype,
+			get: function (element, target, propName) {
+				let returnValue = target[propName];
+				const hook = this.functions[propName];
+				if (hook) {
+					const hookReturnValue = hook.call(element, returnValue, target, propName);
+					if (hookReturnValue) {
+						returnValue = hookReturnValue;
+					}
+				}
+				// Bind to target, otherwise it'll throw an "TypeError: Illegal invocation"
+				return returnValue.bind(target);
+			},
+			functions: {
+				add: function (nativeAddFunc, tokenList, propName) {
+					return (...tokens) => {
+						if (this.__approved) approveElementAttribute(this, 'class');
+						return nativeAddFunc.call(tokenList, ...tokens);
+					};
+				},
+				toggle: function (nativeToggleFunc, tokenList, propName) {
+					return (token, force, ...unused) => {
+						if (this.__approved) approveElementAttribute(this, 'class');
+						return nativeToggleFunc.call(tokenList, token, force, ...unused);
+					};
+				},
+				replace: function (nativeReplaceFunc, tokenList, propName) {
+					return (oldToken, newToken, ...unused) => {
+						if (this.__approved) approveElementAttribute(this, 'class');
+						return nativeReplaceFunc.call(tokenList, oldToken, newToken, ...unused);
+					};
+				}
+			}
 		},
-		get: function () {
-			return contentEditableDescriptor.get.call(this);
+		{
+			propertyName: 'dataset',
+			prototype: HTMLElement.prototype,
+			set: function (element, target, propName, value) {
+				target[propName] = value;
+				const attributeName = camelToKebab(propName);
+				if (element.__approved) approveElementAttribute(element, `data-${attributeName}`);
+				return true;
+			}
 		},
-		configurable: false
-	});
+		{
+			propertyName: 'style',
+			prototype: HTMLElement.prototype,
+			set: function (element, target, propName, value) {
+				target[propName] = value;
+				if (element.__approved) approveElementAttribute(element, 'style');
+				return true;
+			}
+		}
+	];
+
+	// Proxy each property defined in the properties array. A property definition looks like:
+	//
+	// {
+	// 		// The name of the property that will get a new descriptor.
+	// 		propertyName: 'classList',
+	// 		// The object object or prototype that will get a new descriptor.
+	// 		prototype: HTMLElement.prototype,
+	// 		// This is the same as Proxy.prototype.get but with element as first parameter and 'this'
+	// 		// refers the definition itself.
+	// 		get: function(element, target, propName) {
+	// 			return target[propName];
+	// 		},
+	// 		This is the same as Proxy.prototype.set but with element as first parameter and 'this'
+	// 		// refers the definition itself.
+	// 		set: function(element, target, propName, value) {
+	// 			target[propName] = value;
+	// 			return true;
+	// 		}
+	// }
+	const proxyDescriptorsAndvanced = (propertyDefinitions) => {
+
+		propertyDefinitions.forEach((definition) => {
+			const descriptor = Object.getOwnPropertyDescriptor(definition.prototype,
+				definition.propertyName);
+			Object.defineProperty(definition.prototype, definition.propertyName, {
+				configurable: descriptor.configurable,
+				enumerable: descriptor.enumerable,
+				set: function (value) {
+					return descriptor.set.call(this, value);
+				},
+				get: function () {
+					const element = this;
+					const result = descriptor.get.call(element);
+
+					// Proxy property with either get, set, or both. This means that each call
+					// to a child property will be forwarded to the get or set respectively. In
+					// case not get or set is defined, the default get/set behavior applies.
+					if (definition.get || definition.set) {
+						return new Proxy(result, {
+							get: function (target, propName) {
+								if (definition.get) {
+									return definition.get.call(definition, element, target, propName);
+								}
+								return target[propName];
+							},
+							set: function (target, propName, value) {
+								if (definition.set) {
+									return definition.set.call(definition, element, target, propName, value);
+								}
+								target[propName] = value;
+								return true;
+							}
+						});
+					}
+
+					return result;
+				}
+			});
+		});
+	};
+
+	// Proxy properties like 'classList', 'dataset', and 'style'.
+	proxyDescriptorsAndvanced(propertiesElement);
+
 }, coreEvents.PRIORITY.IMMEDIATE);
 
 module.exports = protectedModeModule;

--- a/tests/functional-tests/2-protected-mode.js
+++ b/tests/functional-tests/2-protected-mode.js
@@ -231,4 +231,83 @@ describe('Protected Mode', function () {
 			const attributeValue = await pageB.evaluate(() => document.body.getAttribute('class'));
 			assert.equal(attributeValue, 'class1', 'The id attribute is not \'class1\'');
 		});
+
+	it('classList.contains should work on both clients',
+		async () => {
+			const pageAContainsClass = await util.waitForFunction(pageA, () =>
+				document.body.classList.contains('class1'));
+			assert.isTrue(pageAContainsClass, 'class attribute does not contain \'class1\'');
+
+			const pageBContainsClass = await util.waitForFunction(pageB, () =>
+				document.body.classList.contains('class1'));
+			assert.isTrue(pageBContainsClass, 'class attribute does not contain \'class1\'');
+		});
+
+	it('style properties should be visible as non-transient style attribute on inserting client',
+		async () => {
+			await pageA.evaluate(() => document.body.style.backgroundColor = 'hotpink');
+
+			const hasAttribute = await util.waitForFunction(pageA, () =>
+				document.body.getAttribute('style'));
+			assert.isTrue(hasAttribute, 'style attribute not visible');
+
+			const propertyValue = await pageA.evaluate(() => document.body.style.backgroundColor);
+			assert.equal(propertyValue, 'hotpink',
+				'style.backgroundColor property is not \'hotpink\'');
+
+			const attributeValue = await pageA.evaluate(() =>
+				document.body.getAttribute('style'));
+			assert.equal(attributeValue, 'background-color: hotpink;',
+				'style attribute is not \'background-color: hotpink\'');
+		});
+
+	it('style properties should be visible as non-transient style attribute on other client',
+		async () => {
+			const hasAttribute = await util.waitForFunction(pageB, () =>
+				document.body.getAttribute('style'));
+			assert.isTrue(hasAttribute, 'style attribute not visible');
+
+			const propertyValue = await pageB.evaluate(() => document.body.style.backgroundColor);
+			assert.equal(propertyValue, 'hotpink',
+				'style.backgroundColor property is not \'hotpink\'');
+
+			const attributeValue = await pageB.evaluate(() =>
+				document.body.getAttribute('style'));
+			assert.equal(attributeValue, 'background-color: hotpink;',
+				'style attribute is not \'background-color: hotpink\'');
+		});
+
+	it('dataset properties should be visible as non-transient data-* attribute on inserting client',
+		async () => {
+			await pageA.evaluate(() => document.body.dataset.camelCase = 'kebab-case');
+
+			const hasAttribute = await util.waitForFunction(pageA, () =>
+				document.body.getAttribute('data-camel-case'));
+			assert.isTrue(hasAttribute, 'attribute not visible');
+
+			const datasetValue = await pageA.evaluate(() => document.body.dataset.camelCase);
+			assert.equal(datasetValue, 'kebab-case',
+				'The data-camel-case property is not \'kebab-case\'');
+
+			const attributeValue = await pageA.evaluate(() =>
+				document.body.getAttribute('data-camel-case'));
+			assert.equal(attributeValue, 'kebab-case',
+				'The data-camel-case attribute is not \'kebab-case\'');
+		});
+
+	it('dataset properties should be visible as non-transient data-* attribute on other client',
+		async () => {
+			const hasAttribute = await util.waitForFunction(pageB, () =>
+				document.body.getAttribute('data-camel-case'));
+			assert.isTrue(hasAttribute, 'attribute not visible');
+
+			const datasetValue = await pageB.evaluate(() => document.body.dataset.camelCase);
+			assert.equal(datasetValue, 'kebab-case',
+				'The data-camel-case property is not \'kebab-case\'');
+
+			const attributeValue = await pageB.evaluate(() =>
+				document.body.getAttribute('data-camel-case'));
+			assert.equal(attributeValue, 'kebab-case',
+				'The data-camel-case attribute is not \'kebab-case\'');
+		});
 });


### PR DESCRIPTION
* Changes to an element's dataset or style now correctly approves attributes when webstrate is protected.
* Added a complete list of properties that need to be proxied when webstrate is protected (e.g., tabIndex, title, dir, draggable)
* Fixed attribute approval for Document.importNode
* Added more functional tests for protected mode