### PR TITLE
Fix dataSaved() not working if mutations was introduced in same task.

### DIFF
--- a/client/webstrates/dataSavedEvent.js
+++ b/client/webstrates/dataSavedEvent.js
@@ -10,12 +10,16 @@ let resolves = [];
 // submitted to the database.
 Object.defineProperty(globalObject.publicObject, 'dataSaved', {
 	get: () => () => new Promise((accept, reject) => {
-		// If there are no pending operations (i.e. ops the server is yet to acknowledge), resolve
-		// immediately.
-		if (!coreDatabase.getDocument().hasPending()) accept();
-		// Otherwise, add the promise's accept resolver to a list, so we can resolve it once the
-		// pending operations have been acknowledged.
-		else resolves.push(accept);
+		//Make sure that any mutations are actually picked up by mutation observers.
+		//As dataSaved() might be called in same Task as the mutation introducing code.
+		setTimeout(()=>{
+			// If there are no pending operations (i.e. ops the server is yet to acknowledge), resolve
+			// immediately.
+			if (!coreDatabase.getDocument().hasPending()) accept();
+			// Otherwise, add the promise's accept resolver to a list, so we can resolve it once the
+			// pending operations have been acknowledged.
+			else resolves.push(accept);
+		},0);
 	}),
 	set: () => { throw new Error('dataSaved cannot be overwritten'); },
 	enumerable: true

--- a/helpers/AssetManager.js
+++ b/helpers/AssetManager.js
@@ -103,10 +103,15 @@ const findDuplicateAsset = (asset) =>
  * @return {array}                (async) List of assets.
  * @public
  */
-module.exports.getAssets = function(webstrateId, next) {
+module.exports.getAssets = function(webstrateId, next, latestOnly = false) {
 	return db.assets.find({ webstrateId }, { _id: 0, _originalId: 0, webstrateId: 0 })
 		.toArray(function(err, assets) {
 			if (err) return next && next(err);
+			
+			if(latestOnly) {
+				assets = filterNewestAssets(assets);
+			}
+			
 			assets.forEach(function(asset) {
 				asset.identifier = asset.fileName;
 				asset.fileName = asset.originalFileName;

--- a/helpers/HttpRequestController.js
+++ b/helpers/HttpRequestController.js
@@ -450,13 +450,14 @@ function serveTags(req, res) {
  * @private
  */
 function serveAssets(req, res) {
+	let latestOnly = 'latest' in req.query;
 	assetManager.getAssets(req.webstrateId, function(err, assets) {
 		if (err) {
 			console.error(err);
 			return res.status(409).send(String(err));
 		}
 		res.json(assets);
-	});
+	}, latestOnly);
 }
 
 function serveJsonMLWebstrate(req, res, snapshot) {


### PR DESCRIPTION
When webstrate.dataSaved() is called from the same task that introduced mutations, the mutation observers has not yet seen the mutation, so dataSaved(), thinks there is nothing to wait for.

This is fixed in this commit.