### PR TITLE
Changed addStream to addTrack

### DIFF
--- a/client/webstrates/signalStream.js
+++ b/client/webstrates/signalStream.js
@@ -123,7 +123,9 @@ function WebRTCClient(ownId, recipientId, clientRecipientId, node, { listener, s
 		peerConnection.onicecandidate = gotIceCandidate;
 		peerConnection.oniceconnectionstatechange = gotStateChange;
 		if (streamer) {
-			peerConnection.addStream(localStream);
+			localStream.getTracks().forEach((track)=>{
+				peerConnection.addTrack(track, localStream);
+			});
 			peerConnection.createOffer().then(createdDescription).catch(errorHandler);
 		}
 		if (listener) {


### PR DESCRIPTION
To support browsers that has deprecated / removed addStream, addTrack is now used instead.