### PR TITLE
Upgrade mongodb from 3.4.1 to 3.6.x to prevent errors with Node 14

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "jsonml-tools": "git+http://github.com/Webstrates/jsonml-tools.git#master",
     "md5-file": "4.0.0",
     "mime-types": "2.1.26",
-    "mongodb": "3.4.1",
+    "mongodb": "3.6.x",
     "multer": "1.4.2",
     "optimist": "0.6.1",
     "os": "0.1.1",


### PR DESCRIPTION
Would otherwise print the following on start-up with Node 14.

	[ERROR]  writeOut (internal/process/warning.js:33:3) (node:1) Warning: Accessing non-existent property 'count' of module exports inside circular dependency
	(Use `node --trace-warnings ...` to show where the warning was created)
	[ERROR]  writeOut (internal/process/warning.js:33:3) (node:1) Warning: Accessing non-existent property 'findOne' of module exports inside circular dependency
	[ERROR]  writeOut (internal/process/warning.js:33:3) (node:1) Warning: Accessing non-existent property 'remove' of module exports inside circular dependency
	[ERROR]  writeOut (internal/process/warning.js:33:3) (node:1) Warning: Accessing non-existent property 'updateOne' of module exports inside circular dependency

Note that there are no compatibility changes between the MongoDB driver version 3.4.x and 3.6.x.