### PR TITLE
Support for loggedInToWrite in config

### DIFF
--- a/helpers/PermissionManager.js
+++ b/helpers/PermissionManager.js
@@ -228,10 +228,11 @@ module.exports.expireAllAccessTokens = function(webstrateId, local) {
  * and the given user is anonymous
  * @param  {string}   username    Username.
  * @param  {string}   provider    Login provider (GitHub, Facebook, OAuth, ...).
- * @return {bool}                 The configuration option is set and the user is anonymous
+ * @return {bool}                 The configuration option is set and the user is anonymous.
+ * @private
  */
-async function userMustBeLoggedInToWriteAndUserIsAnonymous(username, provider) {
-	return global.config.loggedInToWrite && username === "anonymous" && provider === "";
+function userMustBeLoggedInToWriteAndUserIsAnonymous(username, provider) {
+	return global.config.loggedInToWrite && username === 'anonymous' && provider === '';
 }
 
 /**
@@ -250,7 +251,9 @@ module.exports.getUserPermissions = async function(username, provider, webstrate
 
 	let permissions = getCachedPermissions(username, provider, webstrateId);
 	if (permissions) {
-		if (await userMustBeLoggedInToWriteAndUserIsAnonymous(username, provider)) permissions = permissions.replace("w", "");
+		if (userMustBeLoggedInToWriteAndUserIsAnonymous(username, provider)) {
+			permissions = permissions.replace(/w/g, '');
+		}
 		return permissions;
 	}
 
@@ -259,7 +262,9 @@ module.exports.getUserPermissions = async function(username, provider, webstrate
 		snapshot);
 
 	setCachedPermissions(username, provider, permissions, snapshot.id);
-	if (await userMustBeLoggedInToWriteAndUserIsAnonymous(username, provider)) permissions = permissions.replace("w", "");
+	if (await userMustBeLoggedInToWriteAndUserIsAnonymous(username, provider)) {
+		permissions = permissions.replace(/w/g, '');
+	}
 	return permissions;
 };
 

--- a/helpers/PermissionManager.js
+++ b/helpers/PermissionManager.js
@@ -251,9 +251,6 @@ module.exports.getUserPermissions = async function(username, provider, webstrate
 
 	let permissions = getCachedPermissions(username, provider, webstrateId);
 	if (permissions) {
-		if (userMustBeLoggedInToWriteAndUserIsAnonymous(username, provider)) {
-			permissions = permissions.replace(/w/g, '');
-		}
 		return permissions;
 	}
 
@@ -261,10 +258,10 @@ module.exports.getUserPermissions = async function(username, provider, webstrate
 	permissions = await module.exports.getUserPermissionsFromSnapshot(username, provider,
 		snapshot);
 
-	setCachedPermissions(username, provider, permissions, snapshot.id);
-	if (await userMustBeLoggedInToWriteAndUserIsAnonymous(username, provider)) {
+	if (userMustBeLoggedInToWriteAndUserIsAnonymous(username, provider)) {
 		permissions = permissions.replace(/w/g, '');
 	}
+	setCachedPermissions(username, provider, permissions, snapshot.id);
 	return permissions;
 };
 

--- a/helpers/PermissionManager.js
+++ b/helpers/PermissionManager.js
@@ -224,6 +224,17 @@ module.exports.expireAllAccessTokens = function(webstrateId, local) {
 };
 
 /**
+ * Check if configuration option is set so users must be logged in to write in a webstrate
+ * and the given user is anonymous
+ * @param  {string}   username    Username.
+ * @param  {string}   provider    Login provider (GitHub, Facebook, OAuth, ...).
+ * @return {bool}                 The configuration option is set and the user is anonymous
+ */
+async function userMustBeLoggedInToWriteAndUserIsAnonymous(username, provider) {
+	return global.config.loggedInToWrite && username === "anonymous" && provider === "";
+}
+
+/**
  * Get a user's permissions for a specific webstrateId.
  * @param  {string}   username    Username.
  * @param  {string}   provider    Login provider (GitHub, Facebook, OAuth, ...).
@@ -239,6 +250,7 @@ module.exports.getUserPermissions = async function(username, provider, webstrate
 
 	let permissions = getCachedPermissions(username, provider, webstrateId);
 	if (permissions) {
+		if (await userMustBeLoggedInToWriteAndUserIsAnonymous(username, provider)) permissions = permissions.replace("w", "");
 		return permissions;
 	}
 
@@ -247,6 +259,7 @@ module.exports.getUserPermissions = async function(username, provider, webstrate
 		snapshot);
 
 	setCachedPermissions(username, provider, permissions, snapshot.id);
+	if (await userMustBeLoggedInToWriteAndUserIsAnonymous(username, provider)) permissions = permissions.replace("w", "");
 	return permissions;
 };
 


### PR DESCRIPTION
Added support for the configuration option "loggedInToWrite" that when set to true will require users to be logged in to make any edits to a webstrate.