### PR TITLE
Test Auth and Invite Tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,6 +81,7 @@
     "eslint": "^9.27.0",
     "eslint-webpack-plugin": "^5.0.1",
     "mocha": "11.7.0",
+    "passport-local": "1.0.0",
     "puppeteer": "24.10.2",
     "webpack-cli": "^6.0.1"
   }

--- a/tests/config.js
+++ b/tests/config.js
@@ -4,7 +4,7 @@ module.exports = {
 	server: require('../helpers/ConfigHelper.js').getConfig(),
 
 	// Auth credentials
-	authType: 'au', // One of 'github', 'au', ...
+	authType: 'test', // One of 'github', 'au', 'test', ...
 	server_address: 'http://localhost:7007/',
 	username: '',
 	password: ''

--- a/tests/functional-tests/2-login.mjs
+++ b/tests/functional-tests/2-login.mjs
@@ -38,7 +38,8 @@ describe('Authentication and Login', function() {
 
 	let authTargetPrefix = {
 	    github: "https://github.com/login?",
-	    au: "https://login.projects.cavi.au.dk"
+	    au: "https://login.projects.cavi.au.dk",
+		test: config.server_address + 'auth/test'
 	}
 	it(`/auth/${config.authType} redirects to ${authTargetPrefix[config.authType]}...`, async function () {
 		if (!util.credentialsProvided) return this.skip();

--- a/tests/functional-tests/4-invites.mjs
+++ b/tests/functional-tests/4-invites.mjs
@@ -5,7 +5,7 @@ import { assert, expect } from 'chai';
 import config from '../config.js';
 import util from '../util.js';
 
-describe.only('Invites', function () {
+describe('Invites', function () {
 	this.timeout(10000);
 
 	const webstrateId = 'test-' + util.randomString();

--- a/tests/functional-tests/4-invites.mjs
+++ b/tests/functional-tests/4-invites.mjs
@@ -5,7 +5,7 @@ import { assert, expect } from 'chai';
 import config from '../config.js';
 import util from '../util.js';
 
-describe('Invites', function() {
+describe.only('Invites', function () {
 	this.timeout(10000);
 
 	const webstrateId = 'test-' + util.randomString();
@@ -18,90 +18,110 @@ describe('Invites', function() {
 		browserB = await puppeteer.launch();
 
 		pageA = await browserA.newPage();
-		if (util.credentialsProvided) {
-			console.log("Logging in...");
-			await util.logInToAuth(pageA);
-			console.log("Logged in...");
-		}
-		pageB = await browserA.newPage();
-		await pageA.goto(url, { waitUntil: 'networkidle2' });
-		await pageB.goto(url, { waitUntil: 'networkidle2' });
+		pageB = await browserB.newPage();
 
-		await Promise.all([
-			util.waitForFunction(pageA, () => window.webstrate && window.webstrate.loaded),
-			util.waitForFunction(pageB, () => window.webstrate && window.webstrate.loaded),
-		]);
+		console.log('Logging in testuserA...');
+		await util.logInToTest(pageA, 'testuserA');
+		console.log('Logged in testuserA...');
+
+		console.log('Logging in testuserB...');
+		await util.logInToTest(pageB, 'testuserB');
+		console.log('Logged in testuserB...');
+
+		await pageA.goto(url, { waitUntil: 'networkidle2' });
+
+		await util.waitForFunction(pageA, () => window.webstrate && window.webstrate.loaded);
 	});
 
 	after(async () => {
-		if (!util.credentialsProvided) {
-			util.warn('Skipping most permission tests as no GitHub credentials were provided.');
-			return;
-		}
-
 		await pageA.goto(url + '?delete', { waitUntil: 'domcontentloaded' }),
 
-		await Promise.all([
-			browserA.close(),
-			browserB.close()
-		]);
+			await Promise.all([
+				browserA.close(),
+				browserB.close()
+			]);
 	});
 
+	it('User A should be able to set permissions', async function () {
+		await pageA.evaluate(() => {
+			document.documentElement.setAttribute('data-auth',
+				JSON.stringify([
+					{
+						username: window.webstrate.user.username,
+						provider: window.webstrate.user.provider,
+						permissions: 'awr'
+					}
+				])
+			);
+		});
+	});
+
+	it('User B should not have access to the webstrate', async function () {
+		const result = await pageB.goto(url, { waitUntil: 'networkidle2' });
+		assert.equal(result.status(), 403);
+	});
 
 	let currentInvitation;
-	it('Creating an invitation with a time limit of 2 seconds should be available immediately: invites.create', async function() {
-		if (!util.credentialsProvided) return this.skip();
+	it('Creating an invitation with a time limit of 2 seconds should be available immediately: invites.create', async function () {
 
-		currentInvitation = await pageA.evaluate(async () => {return await window.webstrate.user.invites.create({
-			permissions: "r",
-			maxAge: "2"
-		})});
+		currentInvitation = await pageA.evaluate(async () => {
+			return await window.webstrate.user.invites.create({
+				permissions: 'r',
+				maxAge: '2'
+			});
+		});
 
-		assert.exists(currentInvitation, "No invitation generated");
-		assert.exists(currentInvitation.key, "Invitation is missin a key");
+		assert.exists(currentInvitation, 'No invitation generated');
+		assert.exists(currentInvitation.key, 'Invitation is missing a key');
 	});
 
-	it('Valid invitation should be in list of currently active invitations: invites.get()', async function() {
-		if (!util.credentialsProvided) return this.skip();
+	it('Valid invitation should be in list of currently active invitations: invites.get()', async function () {
 		const invitations = await pageA.evaluate(() => window.webstrate.user.invites.get());
 
-		assert.exists(invitations.find(m=>m.key===currentInvitation.key), "Invitation not in invites.get() list");
+		assert.exists(invitations.find(m => m.key === currentInvitation.key), 'Invitation not in invites.get() list');
 	});
 
-	it('Valid invitation should be pass validity check and return data: invites.check()', async function() {
-		if (!util.credentialsProvided) return this.skip();
-		const checkedInvitation = await pageA.evaluate((key) => window.webstrate.user.invites.check(key), currentInvitation.key);
+	it('Valid invitation should be pass validity check and return data: invites.check()', async function () {
+		const checkedInvitation = await pageA.evaluate((key) => window.webstrate.user.invites.check(key), currentInvitation.key, url);
 
-		assert.exists(checkedInvitation, "A valid invitation did not pass check(...)");
+		assert.exists(checkedInvitation, 'A valid invitation did not pass check(...)');
 	});
 
-	it('Valid invitation should be in list of currently active invitations for creator: invites.get()', async function() {
-		if (!util.credentialsProvided) return this.skip();
-		const invitations = await pageA.evaluate(() => window.webstrate.user.invites.get());
-
-		assert.exists(invitations.find(m=>m.key===currentInvitation.key), "Invitation not in invites.get() list");
+	it('User B should be able to use the invitation to access the webstrate', async function () {
+		await pageB.goto(config.server_address + 'frontpage', { waitUntil: 'networkidle2' });
+		
+		const result = await pageB.evaluate(async (key, webstrateId) => {
+			return await window.webstrate.user.invites.accept(key, webstrateId);
+		}, currentInvitation.key, webstrateId);
+		
+		assert.equal(result, 'r', 'Invitation was not accepted or returned unexpected permissions');
+	});
+	
+	it('User B should now have access to the webstrate', async function () {
+		const result = await pageB.goto(url, { waitUntil: 'networkidle2' });
+		assert.equal(result.status(), 200, 'User B could not access the webstrate after accepting the invitation');
 	});
 
-	it('Expired invitation should not be in list of currently active invitations: invites.get()', async function() {
-		if (!util.credentialsProvided) return this.skip();
+	it('Expired invitation should not be in list of currently active invitations: invites.get()', async function () {
 
 		// Expire the invitation and try again
-		await new Promise((resolve)=>{setTimeout(resolve, 2000)});		
+		await new Promise((resolve) => { setTimeout(resolve, 2000) });
 		const invitations = await pageA.evaluate(() => window.webstrate.user.invites.get());
 
-		assert.notExists(invitations.find(m=>m.key===currentInvitation.key), "Invitation expired but still in invites.get() list");
+		assert.notExists(invitations.find(m => m.key === currentInvitation.key), 'Invitation expired but still in invites.get() list');
 	});
 
-	it('Expired invitation should be fail validity check: invites.check()', async function() {
-		if (!util.credentialsProvided) return this.skip();
+	it('Expired invitation should be fail validity check: invites.check()', async function () {
 		let error;
 		try {
-		    value = await pageA.evaluate((key) => window.webstrate.user.invites.check(key), currentInvitation.key);
-		} catch (ex){
-		    error = ex;
+			value = await pageA.evaluate((key) => window.webstrate.user.invites.check(key), currentInvitation.key);
+		} catch (ex) {
+			error = ex;
 		}
 		expect(error).to.be.an('Error');
 	});
+	
+	
 
 	// TODO: Accepting an invitation correctly merges permissions with existing ones
 	// TODO: An invite sent by a user which now has lost admin permission becomes invalid

--- a/tests/util.js
+++ b/tests/util.js
@@ -5,7 +5,7 @@ const util = {};
 config.username = config.username || process.env.WEBSTRATES_TEST_USERNAME;
 config.password = config.password || process.env.WEBSTRATES_TEST_PASSWORD;
 
-util.randomString = function(size = 8,
+util.randomString = function (size = 8,
 	alphabet = '23456789abcdefghijkmnpqrstuvwxyzABCDEFGHJKLMNPQRSTUVWXYZ') {
 	let len = alphabet.length, str = '';
 	while (size--) {
@@ -14,17 +14,17 @@ util.randomString = function(size = 8,
 	return str;
 };
 
-util.allEquals = function(x, y, ...rest) {
+util.allEquals = function (x, y, ...rest) {
 	if (y === undefined) return true;
 	if (x !== y) return false;
 	return util.allEquals(y, ...rest);
 };
 
-util.escapeRegExp = function(s) {
+util.escapeRegExp = function (s) {
 	return s.replace(/[-/\\^$*+?.()|[\]{}]/g, '\\$&');
 };
 
-util.webstrateIdRegex =  (config.server && config.server.niceWebstrateIds)
+util.webstrateIdRegex = (config.server && config.server.niceWebstrateIds)
 	? '([a-z]{2,13}-[a-z]{2,13}-\\d{1,3})'
 	: '([A-z0-9-]{8,10})';
 
@@ -47,7 +47,7 @@ util.credentialsProvided = config.authType === 'test' || (config.username && con
  * @return {bool}              True if predicate became truthy false otherwise.
  * @public
  */
-util.waitForFunction = async function(page, fn, timeout = 2, ...args) {
+util.waitForFunction = async function (page, fn, timeout = 2, ...args) {
 	if (typeof timeout !== 'number') {
 		throw new Error(`Invalid timeout: ${timeout}, expected number.`);
 	}
@@ -72,7 +72,7 @@ util.showLogs = (page, ...pages) => {
 
 util.warn = (...args) => console.log('\u001b[33m    ! ' + args + '\u001b[0m');
 
-util.logInToGithub = async function(page) {
+util.logInToGithub = async function (page) {
 	if (!util.credentialsProvided) {
 		throw new Error('No GitHub login credentials provided. Update `config.js` to run GitHub ' +
 			'tests.');
@@ -122,39 +122,39 @@ util.logInToGithub = async function(page) {
 	return true;
 };
 
-util.logInToAU = async function(page) {
-	console.log("Using AU auth...");
+util.logInToAU = async function (page) {
+	console.log('Using AU auth...');
 	if (!util.credentialsProvided) {
 		throw new Error('No au login credentials provided. Update `config.js` to run GitHub ' +
 			'tests.');
 	}
 
-	await page.goto(config.server_address + 'auth/'+config.authType, { waitUntil: 'networkidle0' });
+	await page.goto(config.server_address + 'auth/' + config.authType, { waitUntil: 'networkidle0' });
 	let title = await page.title();
 	if (title !== 'Select an authentication source') {
 		throw new Error(`Incorrect login page title: "${title}"`);
 	}
 
 	// Click on auth type and wait for load
-	await page.waitForSelector('.ldap-au input', {visible: true, timeout: 1000});
-	console.log("Selecting AU auth type...");
+	await page.waitForSelector('.ldap-au input', { visible: true, timeout: 1000 });
+	console.log('Selecting AU auth type...');
 	await page.click('.ldap-au input');
 
 	// Fill in data 
-	await page.waitForSelector('input#username', {visible: true, timeout: 3000});
+	await page.waitForSelector('input#username', { visible: true, timeout: 3000 });
 	title = await page.title();
 	if (title !== 'Enter your username and password') {
 		throw new Error(`Incorrect login page title: "${title}"`);
 	}
-	console.log("Typing in user details...");
+	console.log('Typing in user details...');
 	await page.type('input#username', config.username);
 	await page.type('input#password', config.password);
 	navigationPromise = page.waitForNavigation({ waitUntil: 'networkidle2' });
-	await page.click("button#submit_button");
+	await page.click('button#submit_button');
 	await navigationPromise;
 
 	url = await page.url();
-	console.log("Redirecting to..." + url);
+	console.log('Redirecting to...' + url);
 	// If we get sent back to the GitHub login page, throw whatever error GitHub produced.
 	if (!url.startsWith(config.server_address)) {
 		const flashMsg = await page.evaluate(() =>
@@ -165,8 +165,8 @@ util.logInToAU = async function(page) {
 	return true;
 };
 
-util.logInToTest = async function(page, username = 'testuser') {
-	console.log("Using test auth...");
+util.logInToTest = async function (page, username = 'testuser') {
+	console.log('Using test auth...');
 
 	// Navigate to the test auth form page
 	await page.goto(config.server_address + 'auth/test', { waitUntil: 'networkidle2' });
@@ -184,7 +184,7 @@ util.logInToTest = async function(page, username = 'testuser') {
 	await navigationPromise;
 
 	const url = await page.url();
-	console.log("Redirected to: " + url);
+	console.log('Redirected to: ' + url);
 
 	// Check if we successfully redirected back to the server
 	if (!url.startsWith(config.server_address)) {
@@ -194,30 +194,27 @@ util.logInToTest = async function(page, username = 'testuser') {
 	return true;
 };
 
-util.logInToAuth = async function(page){
-    switch (config.authType){
-	case "github": 
-	    return await util.logInToGithub(page);
-	    break;
-	case "au":
-	    return await util.logInToAU(page);
-	    break;
-	case "test":
-	    return await util.logInToTest(page);
-	    break;
-	default:
-	    throw new Error("Unsupported auth type");
-    }
+util.logInToAuth = async function (page) {
+	switch (config.authType) {
+		case 'github':
+			return await util.logInToGithub(page);
+		case 'au':
+			return await util.logInToAU(page);
+		case 'test':
+			return await util.logInToTest(page);
+		default:
+			throw new Error('Unsupported auth type');
+	}
 }
 
-util.sleep = async function(seconds) {
+util.sleep = async function (seconds) {
 	return new Promise(resolve => setTimeout(resolve, seconds * 1000));
 };
 
 util.waitForWebstrateLoaded = async (page) => {
-	await util.waitForFunction(page, async ()=>{
-		await new Promise((resolve, reject)=>{
-			window.webstrate.on("loaded",()=>{
+	await util.waitForFunction(page, async () => {
+		await new Promise((resolve, reject) => {
+			window.webstrate.on('loaded', () => {
 				resolve();
 			});
 		});

--- a/tests/util.js
+++ b/tests/util.js
@@ -2,8 +2,8 @@ const config = require('./config.js');
 
 const util = {};
 
-config.username = config.username || process.env.GITHUB_USERNAME;
-config.password = config.password || process.env.GITHUB_PASSWORD;
+config.username = config.username || process.env.WEBSTRATES_TEST_USERNAME;
+config.password = config.password || process.env.WEBSTRATES_TEST_PASSWORD;
 
 util.randomString = function(size = 8,
 	alphabet = '23456789abcdefghijkmnpqrstuvwxyzABCDEFGHJKLMNPQRSTUVWXYZ') {

--- a/webstrates.js
+++ b/webstrates.js
@@ -137,17 +137,12 @@ if (config.auth) {
 				usernameField: 'username',
 				passwordField: 'password'
 			}, (username, password, done) => {
-				if (providerConfig.users && providerConfig.users[username] === password) {
-					const profile = {
-						username: username,
-						provider: 'test',
-						displayName: username,
-						id: username
-					};
-					return done(null, profile);
-				} else {
-					return done(null, false, { message: 'Invalid credentials' });
-				}
+				return done(null, {
+					username: username,
+					provider: 'test',
+					displayName: username,
+					id: username
+				});
 			});
 			providerConfig.name = 'local';
 			passport.use(passportInstance);
@@ -170,35 +165,6 @@ if (config.auth) {
 		const strategy = config.auth.providers[key].name;
 
 		if (key === 'test') {
-			app.get('/auth/test', (req, res) => {
-				let referer = req.header('referer');
-				if (req.query.webstrateId) {
-					const origin = new URL(req.header('referer')).origin;
-					referer = origin + '/' + req.query.webstrateId;
-				}
-				req.session.referer = referer;
-
-				// Serve a simple login form
-				res.send(`
-					<html>
-						<body>
-							<h2>Login</h2>
-							<form method="post" action="/auth/test">
-								<div>
-									<label>Username:</label>
-									<input type="text" name="username" required>
-								</div>
-								<div>
-									<label>Password:</label>
-									<input type="password" name="password" required>
-								</div>
-								<button type="submit">Login</button>
-							</form>
-						</body>
-					</html>
-				`);
-			});
-
 			app.post('/auth/test', passport.authenticate('local', {
 				failureRedirect: '/auth/test'
 			}), function (req, res) {

--- a/webstrates.js
+++ b/webstrates.js
@@ -139,6 +139,7 @@ if (config.auth) {
 			}, (username, password, done) => {
 				return done(null, {
 					username: username,
+					userUrl: 'none-for-testing',
 					provider: 'test',
 					displayName: username,
 					id: username
@@ -165,6 +166,34 @@ if (config.auth) {
 		const strategy = config.auth.providers[key].name;
 
 		if (key === 'test') {
+			app.get('/auth/test', (req, res) => {
+				let referer = req.header('referer');
+				if (req.query.webstrateId) {
+					const origin = new URL(req.header('referer')).origin;
+					referer = origin + '/' + req.query.webstrateId;
+				}
+				req.session.referer = referer;
+
+				res.send(`
+					<html>
+						<body>
+							<h2>Test Login</h2>
+							<form method="post" action="/auth/test">
+								<div>
+									<label>Username:</label>
+									<input type="text" name="username" required>
+								</div>
+								<div style="display: none;">
+									<label>Password:</label>
+									<input type="password" name="password" value="test" required>
+								</div>
+								<button type="submit">Login</button>
+							</form>
+						</body>
+					</html>
+				`);
+			});
+
 			app.post('/auth/test', passport.authenticate('local', {
 				failureRedirect: '/auth/test'
 			}), function (req, res) {

--- a/webstrates.js
+++ b/webstrates.js
@@ -128,14 +128,39 @@ if (config.auth) {
 	passport.deserializeUser(sessionManager.deserializeUser);
 
 	for (let key in config.auth.providers) {
-		const PassportStrategy = require(config.auth.providers[key].node_module).Strategy;
-		const passportInstance = new PassportStrategy(config.auth.providers[key].config,
-			(request, accessToken, refreshToken, profile, done) => {
-				profile.provider = key;
-				process.nextTick(() => done(null, profile));
+		const providerConfig = config.auth.providers[key];
+
+		if (key === 'test') {
+			console.warn('The test auth provider is only for testing purposes and should not be used in production.');
+			const PassportStrategy = require('passport-local').Strategy;
+			const passportInstance = new PassportStrategy({
+				usernameField: 'username',
+				passwordField: 'password'
+			}, (username, password, done) => {
+				if (providerConfig.users && providerConfig.users[username] === password) {
+					const profile = {
+						username: username,
+						provider: 'test',
+						displayName: username,
+						id: username
+					};
+					return done(null, profile);
+				} else {
+					return done(null, false, { message: 'Invalid credentials' });
+				}
 			});
-		config.auth.providers[key].name = passportInstance.name;
-		passport.use(passportInstance);
+			providerConfig.name = 'local';
+			passport.use(passportInstance);
+		} else {
+			const PassportStrategy = require(providerConfig.node_module).Strategy;
+			const passportInstance = new PassportStrategy(providerConfig.config,
+				(request, accessToken, refreshToken, profile, done) => {
+					profile.provider = key;
+					process.nextTick(() => done(null, profile));
+				});
+			providerConfig.name = passportInstance.name;
+			passport.use(passportInstance);
+		}
 	}
 
 	app.use(passport.initialize());
@@ -143,24 +168,65 @@ if (config.auth) {
 
 	for (let key in config.auth.providers) {
 		const strategy = config.auth.providers[key].name;
-		app.get('/auth/' + key,
-			(req, res, next) => {
+
+		if (key === 'test') {
+			app.get('/auth/test', (req, res) => {
 				let referer = req.header('referer');
 				if (req.query.webstrateId) {
 					const origin = new URL(req.header('referer')).origin;
 					referer = origin + '/' + req.query.webstrateId;
 				}
 				req.session.referer = referer;
-				next();
-			},
-			passport.authenticate(strategy, config.auth.providers[key].authOptions));
-		app.get('/auth/' + key + '/callback', passport.authenticate(strategy, {
-			failureRedirect: '/auth/' + key
-		}), function(req, res) {
-			let referer = req.session.referer;
-			delete req.session.referer;
-			res.redirect(referer || '/');
-		});
+
+				// Serve a simple login form
+				res.send(`
+					<html>
+						<body>
+							<h2>Login</h2>
+							<form method="post" action="/auth/test">
+								<div>
+									<label>Username:</label>
+									<input type="text" name="username" required>
+								</div>
+								<div>
+									<label>Password:</label>
+									<input type="password" name="password" required>
+								</div>
+								<button type="submit">Login</button>
+							</form>
+						</body>
+					</html>
+				`);
+			});
+
+			app.post('/auth/test', passport.authenticate('local', {
+				failureRedirect: '/auth/test'
+			}), function (req, res) {
+				let referer = req.session.referer;
+				delete req.session.referer;
+				res.redirect(referer || '/');
+			});
+		} else {
+			app.get('/auth/' + key,
+				(req, res, next) => {
+					let referer = req.header('referer');
+					if (req.query.webstrateId) {
+						const origin = new URL(req.header('referer')).origin;
+						referer = origin + '/' + req.query.webstrateId;
+					}
+					req.session.referer = referer;
+					next();
+				},
+				passport.authenticate(strategy, config.auth.providers[key].authOptions));
+			app.get('/auth/' + key + '/callback', passport.authenticate(strategy, {
+				failureRedirect: '/auth/' + key
+			}), function (req, res) {
+				let referer = req.session.referer;
+				delete req.session.referer;
+				res.redirect(referer || '/');
+			});
+		}
+
 		if (WORKER_ID === 1) console.log(strategy + '-based authentication enabled');
 	}
 


### PR DESCRIPTION
**Test Auth Provider**
* Added a "test" authentication provider using `passport-local`, with a simple username-based login form accessible at `/auth/test`. It does not password check and always logs in users. This provider is intended strictly for testing.
* Updated the authentication setup in `webstrates.js` to handle the "test" provider, including GET and POST endpoints for the test login flow. 

**Test Utils**
* Modified test configuration to allow selecting "test" as an `authType`, and updated environment variable handling to use `WEBSTRATES_TEST_USERNAME` and `WEBSTRATES_TEST_PASSWORD` for credentials.
* Added a `logInToTest` utility function for logging in as test users, and updated the main login utility to support the new provider.
* Adjusted the credentials check in the test utilities to treat the "test" provider as always having credentials.

**Invite Tests**
* Implemented tests for the new invite keys API using the new test auth provider that enables to login multiple test users during testing.