### PR TITLE
Additional Tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ uploads
 static/client.html
 static/webstrates.js
 static/webstrates.js.map
+.vscode

--- a/client/webstrates/assets.js
+++ b/client/webstrates/assets.js
@@ -122,7 +122,7 @@ globalObject.publicObject.searchAsset = (assetIdentifier, query = {}, callback) 
 	const [assetName, assetVersion] = assetIdentifier.split('/');
 	websocket.send({ wa: 'assetSearch', d: webstrateId, assetName, assetVersion: +assetVersion,
 		query: query.query, sort: query.sort, limit: query.limit, skip: query.skip },
-	(err, result) => callback(err, result.records, result.count));
+	(err, result) => callback(err, result ? result.records : [], result ? result.count : -1));
 };
 
 module.exports = assetsModule;

--- a/client/webstrates/assets.js
+++ b/client/webstrates/assets.js
@@ -122,7 +122,7 @@ globalObject.publicObject.searchAsset = (assetIdentifier, query = {}, callback) 
 	const [assetName, assetVersion] = assetIdentifier.split('/');
 	websocket.send({ wa: 'assetSearch', d: webstrateId, assetName, assetVersion: +assetVersion,
 		query: query.query, sort: query.sort, limit: query.limit, skip: query.skip },
-	(err, result) => callback(err, result ? result.records : [], result ? result.count : -1));
+	(err, result) => callback(err, result ? result.records : [], result ? result.count : 0));
 };
 
 module.exports = assetsModule;

--- a/helpers/AssetManager.js
+++ b/helpers/AssetManager.js
@@ -351,7 +351,7 @@ module.exports.addAsset = async function(webstrateId, asset, searchable, source)
 	});
 
 	if (searchable && asset.mimetype === 'text/csv') {
-		const assetId = result.ops[0]._id;
+		const assetId = result.insertedId;
 		await searchableAssets.makeSearchable(assetId, module.exports.UPLOAD_DEST + asset.filename);
 	}
 

--- a/helpers/AssetManager.js
+++ b/helpers/AssetManager.js
@@ -350,11 +350,6 @@ module.exports.addAsset = async function(webstrateId, asset, searchable, source)
 		fileHash: asset.fileHash
 	});
 
-	if (searchable && asset.mimetype === 'text/csv') {
-		const assetId = result.insertedId;
-		await searchableAssets.makeSearchable(assetId, module.exports.UPLOAD_DEST + asset.filename);
-	}
-
 	asset = {
 		v: version,
 		fileName: asset.originalname,
@@ -363,6 +358,12 @@ module.exports.addAsset = async function(webstrateId, asset, searchable, source)
 		identifier: asset.filename,
 		fileHash: asset.fileHash
 	};
+
+	if (searchable && asset.mimetype === 'text/csv') {
+		const assetId = result.insertedId;
+		await searchableAssets.makeSearchable(assetId, module.exports.UPLOAD_DEST + asset.filename);
+		asset.searchable = true;
+	}
 
 	// Inform all clients of the newly added asset.
 	clientManager.announceNewAsset(webstrateId, asset, true);

--- a/helpers/AssetManager.js
+++ b/helpers/AssetManager.js
@@ -350,7 +350,7 @@ module.exports.addAsset = async function(webstrateId, asset, searchable, source)
 		fileHash: asset.fileHash
 	});
 
-	asset = {
+	const assetToBeAnnounced = {
 		v: version,
 		fileName: asset.originalname,
 		fileSize: asset.size,
@@ -362,13 +362,13 @@ module.exports.addAsset = async function(webstrateId, asset, searchable, source)
 	if (searchable && asset.mimetype === 'text/csv') {
 		const assetId = result.insertedId;
 		await searchableAssets.makeSearchable(assetId, module.exports.UPLOAD_DEST + asset.filename);
-		asset.searchable = true;
+		assetToBeAnnounced.searchable = true;
 	}
-
+	
 	// Inform all clients of the newly added asset.
-	clientManager.announceNewAsset(webstrateId, asset, true);
+	clientManager.announceNewAsset(webstrateId, assetToBeAnnounced, true);
 
-	return asset;
+	return assetToBeAnnounced;
 };
 
 /**

--- a/helpers/AssetManager.js
+++ b/helpers/AssetManager.js
@@ -109,6 +109,8 @@ module.exports.getAssets = async function(webstrateId, latestOnly = false) {
 		asset.identifier = asset.fileName;
 		asset.fileName = asset.originalFileName;
 		delete asset.originalFileName;
+		delete asset._id;
+		delete asset.webstrateId;
 	});
 	return assets;
 };

--- a/helpers/HttpRequestController.js
+++ b/helpers/HttpRequestController.js
@@ -163,17 +163,17 @@ module.exports.requestHandler = async function(req, res) {
 	}
 
 	try {
-		let snapshot = await documentManager.getDocument({
-			webstrateId: req.webstrateId,
-			version: req.version,
-			tag: req.tag
-		});
-
 		// First check any invite keys - before permissions are fetched
 		if ('acceptInvite' in req.query){
 			await invites.prepareAPIAccess(req.user);
 			await invites.invitee.acceptInvite(req.webstrateId, req.query.acceptInvite, req.user);
-		}		
+		}
+
+		const snapshot = await documentManager.getDocument({
+			webstrateId: req.webstrateId,
+			version: req.version,
+			tag: req.tag
+		});
 
 		req.user.permissions = await permissionManager.getUserPermissionsFromSnapshot(req.user.username,
 			req.user.provider, snapshot);

--- a/middleware/userInvites.js
+++ b/middleware/userInvites.js
@@ -59,11 +59,15 @@ exports.admin = {
      */
     getInvites: async (webstrateId, user) => {
         await exports.admin.checkIsAdmin(webstrateId, user); // First, check if the user is an admin
-        return await db.invites.find({
+        const invites = await db.invites.find({
             webstrateId: webstrateId,
             'createdBy.username': user.username,
             'createdBy.provider': user.provider,
         }).toArray();
+        invites.forEach((invite) => {
+            delete invite._id;
+        });
+        return invites;
     },
 
     /**

--- a/tests/functional-tests/2-login.mjs
+++ b/tests/functional-tests/2-login.mjs
@@ -90,6 +90,9 @@ describe('Authentication and Login', function() {
 		// avatarUrl is optional
 		assert.containsAllKeys(userObject, ['cookies', 'displayName', 'permissions',
 			'provider', 'userId', 'userUrl', 'username']);
+		assert.notEqual(userObject.userId, 'anonymous:');
+		assert.notEqual(userObject.username, 'anonymous');
+		assert.equal(userObject.provider, config.authType);
 	});
 
 	it('user object should have correct userId, username and provider', async function() {
@@ -112,5 +115,25 @@ describe('Authentication and Login', function() {
 		userObject = await pageA.evaluate(() => window.webstrate.user);
 
 		assert.exists(userObject);
+		assert.notEqual(userObject.userId, 'anonymous:');
+		assert.notEqual(userObject.username, 'anonymous');
+		assert.equal(userObject.provider, config.authType);
+	});
+
+	it('after logout user should be redirected to the frontpage and be logged out', async function () {
+		if (!util.credentialsProvided) return this.skip();
+
+		await pageA.goto(config.server_address + 'auth/logout', { waitUntil: 'networkidle2' });
+
+		const url = await pageA.url();
+		assert.equal(url, util.cleanServerAddress + 'frontpage/');
+
+		await util.waitForFunction(pageA, () => window.webstrate && window.webstrate.loaded);
+		userObject = await pageA.evaluate(() => window.webstrate.user);
+
+		assert.propertyVal(userObject, 'userId', 'anonymous:');
+		assert.propertyVal(userObject, 'username', 'anonymous');
+		assert.propertyVal(userObject, 'provider', '');
+		assert.property(userObject, 'permissions');
 	});
 });

--- a/tests/functional-tests/2-login.mjs
+++ b/tests/functional-tests/2-login.mjs
@@ -30,34 +30,33 @@ describe('Authentication and Login', function() {
 		await util.waitForFunction(pageA, () => window.webstrate && window.webstrate.loaded);
 		userObject = await pageA.evaluate(() => window.webstrate.user);
 
-		assert.propertyVal(userObject, 'userId',   'anonymous:');
+		assert.propertyVal(userObject, 'userId', 'anonymous:');
 		assert.propertyVal(userObject, 'username', 'anonymous');
 		assert.propertyVal(userObject, 'provider', '');
-		assert.property(userObject,    'permissions');
+		assert.property(userObject, 'permissions');
 	});
 
 	let authTargetPrefix = {
-	    github: "https://github.com/login?",
-	    au: "https://login.projects.cavi.au.dk",
+		github: 'https://github.com/login?',
+		au: 'https://login.projects.cavi.au.dk',
 		test: config.server_address + 'auth/test'
 	}
 	it(`/auth/${config.authType} redirects to ${authTargetPrefix[config.authType]}...`, async function () {
 		if (!util.credentialsProvided) return this.skip();
 
-		await pageA.goto(config.server_address + 'auth/'+config.authType, { waitUntil: 'networkidle2' });
+		await pageA.goto(config.server_address + 'auth/' + config.authType, { waitUntil: 'networkidle2' });
 		const url = pageA.url();
-		assert.isTrue(url.startsWith(authTargetPrefix[config.authType]), "Was the auth correctly set up in config.json?");
+		assert.isTrue(url.startsWith(authTargetPrefix[config.authType]), 'Was the auth correctly set up in config.json?');
 	});
 
-	it('should log in via auth', async function() {
+	it('should log in via auth', async function () {
 		if (!util.credentialsProvided) return this.skip();
 
-		let result = await util.logInToAuth(pageA);
-		const url = await pageA.url();
+		const result = await util.logInToAuth(pageA);
 		assert.isTrue(result, 'Login failed (invalid credentials?)');
 	});
 
-	it('should redirect to Webstrates frontpage', async function() {
+	it('should redirect to Webstrates frontpage', async function () {
 		if (!util.credentialsProvided) {
 			// We won't get redirected when we're not logging in, so we redirect manually to be in the
 			// right state for the next tests.
@@ -74,14 +73,14 @@ describe('Authentication and Login', function() {
 	});
 
 	let userObject;
-	it('user object should exist', async function() {
+	it('user object should exist', async function () {
 		await util.waitForFunction(pageA, () => window.webstrate && window.webstrate.loaded);
 		userObject = await pageA.evaluate(() => window.webstrate.user);
 
 		assert.exists(userObject);
 	});
 
-	it('user object should contain all required keys', async function() {
+	it('user object should contain all required keys', async function () {
 		if (!util.credentialsProvided) {
 			assert.containsAllKeys(userObject, ['permissions', 'provider', 'userId', 'username']);
 			return;
@@ -90,23 +89,19 @@ describe('Authentication and Login', function() {
 		// avatarUrl is optional
 		assert.containsAllKeys(userObject, ['cookies', 'displayName', 'permissions',
 			'provider', 'userId', 'userUrl', 'username']);
-		assert.notEqual(userObject.userId, 'anonymous:');
-		assert.notEqual(userObject.username, 'anonymous');
-		assert.equal(userObject.provider, config.authType);
 	});
 
-	it('user object should have correct userId, username and provider', async function() {
+	it('user object should have correct userId, username and provider', async function () {
 		if (!util.credentialsProvided) return this.skip();
 
 
-		assert.equal(userObject.userId, userObject.username+":"+config.authType);
-		assert.isTrue(userObject.username!="anonymous", "User cannot be called anonymous");
+		assert.equal(userObject.userId, userObject.username + ':' + config.authType);
+		assert.isTrue(userObject.username != 'anonymous', 'User cannot be called anonymous');
 		assert.propertyVal(userObject, 'provider', config.authType);
 	});
 
-	it('should also log in on other pages/tabs', async function() {
+	it('should also log in on other pages/tabs', async function () {
 		if (!util.credentialsProvided) return this.skip();
-
 
 		pageB = await browser.newPage();
 		await pageB.goto(config.server_address);

--- a/tests/functional-tests/3-assets.mjs
+++ b/tests/functional-tests/3-assets.mjs
@@ -11,20 +11,45 @@ import archiver from 'archiver';
 
 const IMAGE_DATA = `data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAYAAABzenr0AAAFzGlUWHRYTUw6Y29tLmFkb2JlLnhtcAAAAAAAPD94cGFja2V0IGJlZ2luPSLvu78iIGlkPSJXNU0wTXBDZWhpSHpyZVN6TlRjemtjOWQiPz4KPHg6eG1wbWV0YSB4bWxuczp4PSJhZG9iZTpuczptZXRhLyIgeDp4bXB0az0iWE1QIENvcmUgNS41LjAiPgogPHJkZjpSREYgeG1sbnM6cmRmPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5LzAyLzIyLXJkZi1zeW50YXgtbnMjIj4KICA8cmRmOkRlc2NyaXB0aW9uIHJkZjphYm91dD0iIgogICAgeG1sbnM6ZXhpZj0iaHR0cDovL25zLmFkb2JlLmNvbS9leGlmLzEuMC8iCiAgICB4bWxuczpwaG90b3Nob3A9Imh0dHA6Ly9ucy5hZG9iZS5jb20vcGhvdG9zaG9wLzEuMC8iCiAgICB4bWxuczp0aWZmPSJodHRwOi8vbnMuYWRvYmUuY29tL3RpZmYvMS4wLyIKICAgIHhtbG5zOnhtcD0iaHR0cDovL25zLmFkb2JlLmNvbS94YXAvMS4wLyIKICAgIHhtbG5zOnhtcE1NPSJodHRwOi8vbnMuYWRvYmUuY29tL3hhcC8xLjAvbW0vIgogICAgeG1sbnM6c3RFdnQ9Imh0dHA6Ly9ucy5hZG9iZS5jb20veGFwLzEuMC9zVHlwZS9SZXNvdXJjZUV2ZW50IyIKICAgZXhpZjpDb2xvclNwYWNlPSIxIgogICBleGlmOlBpeGVsWERpbWVuc2lvbj0iMzIiCiAgIGV4aWY6UGl4ZWxZRGltZW5zaW9uPSIzMiIKICAgcGhvdG9zaG9wOkNvbG9yTW9kZT0iMyIKICAgcGhvdG9zaG9wOklDQ1Byb2ZpbGU9InNSR0IgSUVDNjE5NjYtMi4xIgogICB0aWZmOkltYWdlTGVuZ3RoPSIzMiIKICAgdGlmZjpJbWFnZVdpZHRoPSIzMiIKICAgdGlmZjpSZXNvbHV0aW9uVW5pdD0iMiIKICAgdGlmZjpYUmVzb2x1dGlvbj0iNzIvMSIKICAgdGlmZjpZUmVzb2x1dGlvbj0iNzIvMSIKICAgeG1wOk1ldGFkYXRhRGF0ZT0iMjAyNS0wOC0xOFQxMjo0MTo0MyswMjowMCIKICAgeG1wOk1vZGlmeURhdGU9IjIwMjUtMDgtMThUMTI6NDE6NDMrMDI6MDAiPgogICA8eG1wTU06SGlzdG9yeT4KICAgIDxyZGY6U2VxPgogICAgIDxyZGY6bGkKICAgICAgeG1wTU06YWN0aW9uPSJwcm9kdWNlZCIKICAgICAgeG1wTU06c29mdHdhcmVBZ2VudD0iQWZmaW5pdHkgRGVzaWduZXIgMS4xMC41IgogICAgICB4bXBNTTp3aGVuPSIyMDIyLTA4LTExVDEwOjU5OjI5KzAyOjAwIi8+CiAgICAgPHJkZjpsaQogICAgICB4bXBNTTphY3Rpb249InByb2R1Y2VkIgogICAgICB4bXBNTTpzb2Z0d2FyZUFnZW50PSJBZmZpbml0eSBQaG90byAxLjEwLjUiCiAgICAgIHhtcE1NOndoZW49IjIwMjItMDgtMTFUMTU6MDc6MDMrMDI6MDAiLz4KICAgICA8cmRmOmxpCiAgICAgIHN0RXZ0OmFjdGlvbj0icHJvZHVjZWQiCiAgICAgIHN0RXZ0OnNvZnR3YXJlQWdlbnQ9IkFmZmluaXR5IFBob3RvIDIgMi42LjMiCiAgICAgIHN0RXZ0OndoZW49IjIwMjUtMDgtMThUMTI6NDE6NDMrMDI6MDAiLz4KICAgIDwvcmRmOlNlcT4KICAgPC94bXBNTTpIaXN0b3J5PgogIDwvcmRmOkRlc2NyaXB0aW9uPgogPC9yZGY6UkRGPgo8L3g6eG1wbWV0YT4KPD94cGFja2V0IGVuZD0iciI/PvZnu+8AAAGCaUNDUHNSR0IgSUVDNjE5NjYtMi4xAAAokXWRzytEURTHPzOIxmiEhYXFpCGLGTFqsFFm0lCTpjHKr83MMz/U/Hi9N9Jkq2wVJTZ+LfgL2CprpYiUrNkSG/ScZ9RMMud27vnc773ndO+5YI1mlKxe2wfZXEGLBP3Omdk5Z/0zDbRgo4fBmKKro+FwiKr2fovFjNces1b1c/9a42JCV8DSIDyiqFpBeFw4tFJQTd4SblPSsUXhE2G3JhcUvjH1eImfTE6V+NNkLRoJgLVZ2Jmq4HgFK2ktKywvx5XNLCu/9zFfYk/kpqckdop3oBMhiB8nE4wRwEc/wzL78OClV1ZUye/7yZ8kL7mKzCpFNJZIkaaAW9RlqZ6QmBQ9ISND0ez/377qyQFvqbrdD3WPhvHaBfWb8LVhGB8HhvF1CDUPcJ4r5+f3YehN9I2y5toDxxqcXpS1+DacrUP7vRrTYj9Sjbg1mYSXY2iahdYrsM2Xeva7z9EdRFflqy5hZxe65bxj4Ruejmf/iAWTSgAAAAlwSFlzAAALEwAACxMBAJqcGAAAAmxJREFUWIXtlt+LTVEUxz9z75Dp5ncuZcp48uuBFA/Kg19RyqPhYfDkR8xfoIaUSPJChJKm/MqDvMjPJ7pJYe4TKYQYZcyYGt0rcx0P+5xa1l3rnFNe76pd9+z92eu79rp77b2hZS371+YAZ4FB4BcwAlSAdf/ptwd4AdSAH8AdoEtDJeADEBltHFiTIlAGNsRtrhrb6Ph8CRQluMwBk3bdEd8O/BZcA9gvxg+k+NwmHbUBZ1Lgu4b4LMLfpNkBwUwFvjg+TxYEGMXRnnZW+tHoOwhMM/rfiN+jwEXHZ6lgdFYduKK+u4C9DntefT9yuIlWZz/NqWoQKiSLi4Dnhs+yw17Q4ATguwE+VtzyOCjLabezUos9rsEtDihT3QY8cbh3QLsRQIfD92jwpgHVgBmC2ek4i4BeQxxggcH+ATolNB2oG+BVwcwGhhzxUcJhZtkOg3+qoT2O4/WCuZWyer3zpd0w+KYKqhjQeyAp1d0p4hGwyhEv05zZYWCKhBY5Tg/F4ysIe8ETHxKBajtq8H0aOmFADWAe4XL5lLH6+454J/BTsZ/16ovYZ/UDwjlezRCPgMuGeAG4Z7BbNbjWcdpLOIBk31fgmcH2GwEcMbgrVpqs9EfAW/U9BqwErhmsvD/agWMG8wqV+sRuOwHIVgc2xfwph7lE2FyvjbFBjBdQYg8zxGvAZsF35whYb7rFnnhWBkaA1YovEeo4j/gAMD9NHGCfM7kKLHTmeKdm0sYJD5uOLHEI5XKOcDlEwDfgMDApY94umst3jHB3LM0jDOFqTWwmMJlw6DRyzi8CSwhvw2HCTq/nFW9ZywD+Al9yhORsjkEmAAAAAElFTkSuQmCC`;
 
+const uploadAssetHelper = async (page, testAsset) => {
+	const fileChooserPromise = page.waitForFileChooser();
+
+	await page.evaluate(() => {
+		window.testAssetUploaded = false;
+		window.webstrate.uploadAsset(() => {
+			window.testAssetUploaded = true;
+		});
+	});
+
+	const fileChooser = await fileChooserPromise;
+	await fileChooser.accept([testAsset]);
+
+	await page.waitForFunction(() => {
+		return window.testAssetUploaded === true;
+	}, { timeout: 5000 });
+}
+
 describe.only('Assets', function () {
 	this.timeout(10000);
 
-	const webstrateId = 'test-' + util.randomString();
-	const url = config.server_address + webstrateId;
+	const webstrateIdA = 'test-' + util.randomString();
+	const webstrateIdB = 'test-' + util.randomString();
+	const urlA = config.server_address + webstrateIdA;
+	const urlB = config.server_address + webstrateIdB;
 
-	let browser, page;
+	const textFileContent = 'This is a test file for asset testing.' + util.randomString(10);
+
+	let browserA, browserB, pageA, pageB;
 	let testDir;
-	let testAssets = [];
+	let testAssetsFs = [];
 
 	before(async () => {
-		browser = await puppeteer.launch();
-		page = await browser.newPage();
-		await page.goto(url, { waitUntil: 'domcontentloaded' });
+		browserA = await puppeteer.launch();
+		browserB = await puppeteer.launch();
+		pageA = await browserA.newPage();
+		pageB = await browserB.newPage();
+		await pageA.goto(urlA, { waitUntil: 'networkidle2' });
+		await pageB.goto(urlB, { waitUntil: 'networkidle2' });
 
 		// Create test folder and files
 		testDir = path.join(process.cwd(), 'tests', 'test-assets');
@@ -34,21 +59,19 @@ describe.only('Assets', function () {
 
 		// Create a simple text file
 		const textFile = path.join(testDir, 'test.txt');
-		fs.writeFileSync(textFile, 'This is a test file for asset testing.');
-		testAssets.push(textFile);
+		fs.writeFileSync(textFile, textFileContent);
+		testAssetsFs.push(textFile);
 
 		// Create a simple CSV file for searchable assets
 		const csvFile = path.join(testDir, 'test.csv');
 		fs.writeFileSync(csvFile, 'name,age,city\nJohn,25,New York\nJane,30,Los Angeles\nBob,35,Chicago');
-		testAssets.push(csvFile);
+		testAssetsFs.push(csvFile);
 
 		// Create an image file
 		const imageFile = path.join(testDir, 'test.png');
 		fs.writeFileSync(imageFile, Buffer.from(IMAGE_DATA.split(',')[1], 'base64'));
-		testAssets.push(imageFile);
+		testAssetsFs.push(imageFile);
 
-
-		// Create ZIP file using a Promise to ensure it completes before continuing
 		// Create a simple ZIP with the above files
 		const zipFile = path.join(testDir, 'test.zip');
 		await new Promise((resolve, reject) => {
@@ -69,12 +92,12 @@ describe.only('Assets', function () {
 			archive.file(imageFile, { name: 'test.png' });
 			archive.finalize();
 		});
-		testAssets.push(zipFile);
+		testAssetsFs.push(zipFile);
 	});
 
 	after(async () => {
 		// Clean up test files
-		testAssets.forEach(file => {
+		testAssetsFs.forEach(file => {
 			if (fs.existsSync(file)) {
 				fs.unlinkSync(file);
 			}
@@ -83,32 +106,117 @@ describe.only('Assets', function () {
 			fs.rmdirSync(testDir);
 		}
 
-		await page.goto(url + '?delete', { waitUntil: 'domcontentloaded' });
-		await browser.close();
+		await pageA.goto(urlA + '?delete', { waitUntil: 'domcontentloaded' });
+		await pageB.goto(urlB + '?delete', { waitUntil: 'domcontentloaded' });
+		await browserA.close();
 	});
 
-	it('Users should be able to upload assets', async () => {
+	it('Users should be able to upload assets using the API', async () => {
+		await uploadAssetHelper(pageA, testAssetsFs[0]);
 
+		const assets = await pageA.evaluate(async () => {
+			return await window.webstrate.assets;
+		});
+
+		assert.equal(assets.length, 1, 'No assets found after upload');
+		assert
+		assert.equal(assets[0].fileName, 'test.txt', 'Uploaded asset file name does not match');
+		assert.equal(assets[0].mimeType, 'text/plain', 'Uploaded asset file type does not match');
+		assert.hasAllKeys(assets[0], ['v', 'fileName', 'fileSize', 'mimeType', 'identifier', 'fileHash'], 'Uploaded asset does not have all expected properties');
 	});
 
 	it('Assets should be accessible from their URL', async () => {
+		await pageA.goto(urlA + '/test.txt', { waitUntil: 'networkidle2' });
 
+		const content = await pageA.evaluate(() => {
+			return document.body.textContent;
+		});
+		assert.equal(content, textFileContent, 'Content of the asset does not match the expected content');
 	});
 
-	it('Assets should be accessible from the API', async () => {
+	it('All assets should be listed in the API', async () => {
+		await pageA.goto(urlA, { waitUntil: 'networkidle2' });
 
+		await uploadAssetHelper(pageA, testAssetsFs[1]);
+		await uploadAssetHelper(pageA, testAssetsFs[2]);
+		await uploadAssetHelper(pageA, testAssetsFs[3]);
+
+		const assets = await pageA.evaluate(async () => {
+			return await window.webstrate.assets;
+		});
+
+		assert.equal(assets.length, 4, 'The number of assets in the list does not match the number of uploaded assets');
+	});
+
+	it('The same asset should have the same identifier across different webstrates', async () => {
+		await uploadAssetHelper(pageB, testAssetsFs[0]);
+
+		const textFileAssetA = await pageA.evaluate(() => {
+			return window.webstrate.assets.find(asset => asset.fileName === 'test.txt');
+		});
+		const textFileAssetB = await pageB.evaluate(() => {
+			return window.webstrate.assets.find(asset => asset.fileName === 'test.txt');
+		});
+
+		assert.equal(textFileAssetA.identifier, textFileAssetB.identifier, 'The identifiers of the same asset in different webstrates do not match');
 	});
 
 	it('Assets should be able to be deleted', async () => {
+		await pageB.evaluate(async () => {
+			window.testAssetDeleted = false;
+			window.webstrate.deleteAsset('test.txt', () => {
+				window.testAssetDeleted = true;
+			});
+		});
 
+		await pageB.waitForFunction(() => {
+			return window.testAssetDeleted === true;
+		}, { timeout: 5000 });
+
+		await pageB.reload({ waitUntil: 'networkidle2' });
+
+		const textFileAssetB = await pageB.evaluate(() => {
+			return window.webstrate.assets.find(asset => asset.fileName === 'test.txt');
+		});
+
+		assert.isNumber(textFileAssetB.deletedAt, 'Asset was not deleted successfully');
 	});
 
-	it('Files within ZIP archives should be listable', async () => {
+	it('Assets with the same identifier should still be accessible after deletion on another webstrate', async () => {
+		await pageA.reload({ waitUntil: 'networkidle2' });
 
+		const textFileAssetA = await pageA.evaluate(() => {
+			return window.webstrate.assets.find(asset => asset.fileName === 'test.txt');
+		});
+
+		assert.isDefined(textFileAssetA, 'Asset should still be defined on webstrate A after deletion on webstrate B');
+	});
+
+	it('Files within ZIP archives should be listable using the HTTP API', async () => {
+		await pageA.goto(urlA + '/test.zip/?dir', { waitUntil: 'networkidle2' });
+
+		const content = await pageA.evaluate(() => {
+			return document.body.textContent;
+		});
+		
+		try {
+			const assetsList = JSON.parse(content);
+			assert.isArray(assetsList, 'Content of the ZIP archive should be a JSON array');
+			assert.include(assetsList, 'test.txt', 'Content of the ZIP archive does not contain the expected file');
+			assert.include(assetsList, 'test.csv', 'Content of the ZIP archive does not contain the expected file');
+			assert.include(assetsList, 'test.png', 'Content of the ZIP archive does not contain the expected file');
+		} catch (error) {
+			assert.fail('Content of the ZIP archive is not a valid JSON array: ' + error.message);
+		}
 	});
 
 	it('Files within ZIP archives should be directly accessible via their URL', async () => {
+		await pageA.goto(urlA + '/test.zip/test.txt', { waitUntil: 'networkidle2' });
 
+		const content = await pageA.evaluate(() => {
+			return document.body.textContent;
+		});
+		assert.equal(content, textFileContent, 'Content of the file within ZIP archive does not match the expected content');
 	});
 
 	// TODO: Searchable CSVs?

--- a/tests/functional-tests/3-assets.mjs
+++ b/tests/functional-tests/3-assets.mjs
@@ -44,7 +44,7 @@ const deleteAssetHelper = async (page, fileName) => {
 	await page.reload({ waitUntil: 'networkidle2' });
 }
 
-describe.only('Assets', function () {
+describe('Assets', function () {
 	this.timeout(10000);
 
 	const webstrateIdA = 'test-' + util.randomString();

--- a/tests/functional-tests/3-assets.mjs
+++ b/tests/functional-tests/3-assets.mjs
@@ -1,0 +1,115 @@
+// Instruction to ESLint that 'describe', 'before', 'after' and 'it' actually has been defined.
+/* global describe before after it */
+import puppeteer from 'puppeteer';
+import { assert, expect } from 'chai';
+import config from '../config.js';
+import util from '../util.js';
+
+import fs from 'fs';
+import path from 'path';
+import archiver from 'archiver';
+
+const IMAGE_DATA = `data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAYAAABzenr0AAAFzGlUWHRYTUw6Y29tLmFkb2JlLnhtcAAAAAAAPD94cGFja2V0IGJlZ2luPSLvu78iIGlkPSJXNU0wTXBDZWhpSHpyZVN6TlRjemtjOWQiPz4KPHg6eG1wbWV0YSB4bWxuczp4PSJhZG9iZTpuczptZXRhLyIgeDp4bXB0az0iWE1QIENvcmUgNS41LjAiPgogPHJkZjpSREYgeG1sbnM6cmRmPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5LzAyLzIyLXJkZi1zeW50YXgtbnMjIj4KICA8cmRmOkRlc2NyaXB0aW9uIHJkZjphYm91dD0iIgogICAgeG1sbnM6ZXhpZj0iaHR0cDovL25zLmFkb2JlLmNvbS9leGlmLzEuMC8iCiAgICB4bWxuczpwaG90b3Nob3A9Imh0dHA6Ly9ucy5hZG9iZS5jb20vcGhvdG9zaG9wLzEuMC8iCiAgICB4bWxuczp0aWZmPSJodHRwOi8vbnMuYWRvYmUuY29tL3RpZmYvMS4wLyIKICAgIHhtbG5zOnhtcD0iaHR0cDovL25zLmFkb2JlLmNvbS94YXAvMS4wLyIKICAgIHhtbG5zOnhtcE1NPSJodHRwOi8vbnMuYWRvYmUuY29tL3hhcC8xLjAvbW0vIgogICAgeG1sbnM6c3RFdnQ9Imh0dHA6Ly9ucy5hZG9iZS5jb20veGFwLzEuMC9zVHlwZS9SZXNvdXJjZUV2ZW50IyIKICAgZXhpZjpDb2xvclNwYWNlPSIxIgogICBleGlmOlBpeGVsWERpbWVuc2lvbj0iMzIiCiAgIGV4aWY6UGl4ZWxZRGltZW5zaW9uPSIzMiIKICAgcGhvdG9zaG9wOkNvbG9yTW9kZT0iMyIKICAgcGhvdG9zaG9wOklDQ1Byb2ZpbGU9InNSR0IgSUVDNjE5NjYtMi4xIgogICB0aWZmOkltYWdlTGVuZ3RoPSIzMiIKICAgdGlmZjpJbWFnZVdpZHRoPSIzMiIKICAgdGlmZjpSZXNvbHV0aW9uVW5pdD0iMiIKICAgdGlmZjpYUmVzb2x1dGlvbj0iNzIvMSIKICAgdGlmZjpZUmVzb2x1dGlvbj0iNzIvMSIKICAgeG1wOk1ldGFkYXRhRGF0ZT0iMjAyNS0wOC0xOFQxMjo0MTo0MyswMjowMCIKICAgeG1wOk1vZGlmeURhdGU9IjIwMjUtMDgtMThUMTI6NDE6NDMrMDI6MDAiPgogICA8eG1wTU06SGlzdG9yeT4KICAgIDxyZGY6U2VxPgogICAgIDxyZGY6bGkKICAgICAgeG1wTU06YWN0aW9uPSJwcm9kdWNlZCIKICAgICAgeG1wTU06c29mdHdhcmVBZ2VudD0iQWZmaW5pdHkgRGVzaWduZXIgMS4xMC41IgogICAgICB4bXBNTTp3aGVuPSIyMDIyLTA4LTExVDEwOjU5OjI5KzAyOjAwIi8+CiAgICAgPHJkZjpsaQogICAgICB4bXBNTTphY3Rpb249InByb2R1Y2VkIgogICAgICB4bXBNTTpzb2Z0d2FyZUFnZW50PSJBZmZpbml0eSBQaG90byAxLjEwLjUiCiAgICAgIHhtcE1NOndoZW49IjIwMjItMDgtMTFUMTU6MDc6MDMrMDI6MDAiLz4KICAgICA8cmRmOmxpCiAgICAgIHN0RXZ0OmFjdGlvbj0icHJvZHVjZWQiCiAgICAgIHN0RXZ0OnNvZnR3YXJlQWdlbnQ9IkFmZmluaXR5IFBob3RvIDIgMi42LjMiCiAgICAgIHN0RXZ0OndoZW49IjIwMjUtMDgtMThUMTI6NDE6NDMrMDI6MDAiLz4KICAgIDwvcmRmOlNlcT4KICAgPC94bXBNTTpIaXN0b3J5PgogIDwvcmRmOkRlc2NyaXB0aW9uPgogPC9yZGY6UkRGPgo8L3g6eG1wbWV0YT4KPD94cGFja2V0IGVuZD0iciI/PvZnu+8AAAGCaUNDUHNSR0IgSUVDNjE5NjYtMi4xAAAokXWRzytEURTHPzOIxmiEhYXFpCGLGTFqsFFm0lCTpjHKr83MMz/U/Hi9N9Jkq2wVJTZ+LfgL2CprpYiUrNkSG/ScZ9RMMud27vnc773ndO+5YI1mlKxe2wfZXEGLBP3Omdk5Z/0zDbRgo4fBmKKro+FwiKr2fovFjNces1b1c/9a42JCV8DSIDyiqFpBeFw4tFJQTd4SblPSsUXhE2G3JhcUvjH1eImfTE6V+NNkLRoJgLVZ2Jmq4HgFK2ktKywvx5XNLCu/9zFfYk/kpqckdop3oBMhiB8nE4wRwEc/wzL78OClV1ZUye/7yZ8kL7mKzCpFNJZIkaaAW9RlqZ6QmBQ9ISND0ez/377qyQFvqbrdD3WPhvHaBfWb8LVhGB8HhvF1CDUPcJ4r5+f3YehN9I2y5toDxxqcXpS1+DacrUP7vRrTYj9Sjbg1mYSXY2iahdYrsM2Xeva7z9EdRFflqy5hZxe65bxj4Ruejmf/iAWTSgAAAAlwSFlzAAALEwAACxMBAJqcGAAAAmxJREFUWIXtlt+LTVEUxz9z75Dp5ncuZcp48uuBFA/Kg19RyqPhYfDkR8xfoIaUSPJChJKm/MqDvMjPJ7pJYe4TKYQYZcyYGt0rcx0P+5xa1l3rnFNe76pd9+z92eu79rp77b2hZS371+YAZ4FB4BcwAlSAdf/ptwd4AdSAH8AdoEtDJeADEBltHFiTIlAGNsRtrhrb6Ph8CRQluMwBk3bdEd8O/BZcA9gvxg+k+NwmHbUBZ1Lgu4b4LMLfpNkBwUwFvjg+TxYEGMXRnnZW+tHoOwhMM/rfiN+jwEXHZ6lgdFYduKK+u4C9DntefT9yuIlWZz/NqWoQKiSLi4Dnhs+yw17Q4ATguwE+VtzyOCjLabezUos9rsEtDihT3QY8cbh3QLsRQIfD92jwpgHVgBmC2ek4i4BeQxxggcH+ATolNB2oG+BVwcwGhhzxUcJhZtkOg3+qoT2O4/WCuZWyer3zpd0w+KYKqhjQeyAp1d0p4hGwyhEv05zZYWCKhBY5Tg/F4ysIe8ETHxKBajtq8H0aOmFADWAe4XL5lLH6+454J/BTsZ/16ovYZ/UDwjlezRCPgMuGeAG4Z7BbNbjWcdpLOIBk31fgmcH2GwEcMbgrVpqs9EfAW/U9BqwErhmsvD/agWMG8wqV+sRuOwHIVgc2xfwph7lE2FyvjbFBjBdQYg8zxGvAZsF35whYb7rFnnhWBkaA1YovEeo4j/gAMD9NHGCfM7kKLHTmeKdm0sYJD5uOLHEI5XKOcDlEwDfgMDApY94umst3jHB3LM0jDOFqTWwmMJlw6DRyzi8CSwhvw2HCTq/nFW9ZywD+Al9yhORsjkEmAAAAAElFTkSuQmCC`;
+
+describe.only('Assets', function () {
+	this.timeout(10000);
+
+	const webstrateId = 'test-' + util.randomString();
+	const url = config.server_address + webstrateId;
+
+	let browser, page;
+	let testDir;
+	let testAssets = [];
+
+	before(async () => {
+		browser = await puppeteer.launch();
+		page = await browser.newPage();
+		await page.goto(url, { waitUntil: 'domcontentloaded' });
+
+		// Create test folder and files
+		testDir = path.join(process.cwd(), 'tests', 'test-assets');
+		if (!fs.existsSync(testDir)) {
+			fs.mkdirSync(testDir, { recursive: true });
+		}
+
+		// Create a simple text file
+		const textFile = path.join(testDir, 'test.txt');
+		fs.writeFileSync(textFile, 'This is a test file for asset testing.');
+		testAssets.push(textFile);
+
+		// Create a simple CSV file for searchable assets
+		const csvFile = path.join(testDir, 'test.csv');
+		fs.writeFileSync(csvFile, 'name,age,city\nJohn,25,New York\nJane,30,Los Angeles\nBob,35,Chicago');
+		testAssets.push(csvFile);
+
+		// Create an image file
+		const imageFile = path.join(testDir, 'test.png');
+		fs.writeFileSync(imageFile, Buffer.from(IMAGE_DATA.split(',')[1], 'base64'));
+		testAssets.push(imageFile);
+
+
+		// Create ZIP file using a Promise to ensure it completes before continuing
+		// Create a simple ZIP with the above files
+		const zipFile = path.join(testDir, 'test.zip');
+		await new Promise((resolve, reject) => {
+			const output = fs.createWriteStream(zipFile);
+			const archive = archiver('zip');
+
+			output.on('close', () => {
+				resolve();
+			});
+			archive.on('error', (err) => {
+				reject(err);
+			});
+
+			// Add files to the archive
+			archive.pipe(output);
+			archive.file(textFile, { name: 'test.txt' });
+			archive.file(csvFile, { name: 'test.csv' });
+			archive.file(imageFile, { name: 'test.png' });
+			archive.finalize();
+		});
+		testAssets.push(zipFile);
+	});
+
+	after(async () => {
+		// Clean up test files
+		testAssets.forEach(file => {
+			if (fs.existsSync(file)) {
+				fs.unlinkSync(file);
+			}
+		});
+		if (fs.existsSync(testDir)) {
+			fs.rmdirSync(testDir);
+		}
+
+		await page.goto(url + '?delete', { waitUntil: 'domcontentloaded' });
+		await browser.close();
+	});
+
+	it('Users should be able to upload assets', async () => {
+
+	});
+
+	it('Assets should be accessible from their URL', async () => {
+
+	});
+
+	it('Assets should be accessible from the API', async () => {
+
+	});
+
+	it('Assets should be able to be deleted', async () => {
+
+	});
+
+	it('Files within ZIP archives should be listable', async () => {
+
+	});
+
+	it('Files within ZIP archives should be directly accessible via their URL', async () => {
+
+	});
+
+	// TODO: Searchable CSVs?
+});

--- a/tests/functional-tests/3-assets.mjs
+++ b/tests/functional-tests/3-assets.mjs
@@ -11,15 +11,15 @@ import archiver from 'archiver';
 
 const IMAGE_DATA = `data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAYAAABzenr0AAAFzGlUWHRYTUw6Y29tLmFkb2JlLnhtcAAAAAAAPD94cGFja2V0IGJlZ2luPSLvu78iIGlkPSJXNU0wTXBDZWhpSHpyZVN6TlRjemtjOWQiPz4KPHg6eG1wbWV0YSB4bWxuczp4PSJhZG9iZTpuczptZXRhLyIgeDp4bXB0az0iWE1QIENvcmUgNS41LjAiPgogPHJkZjpSREYgeG1sbnM6cmRmPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5LzAyLzIyLXJkZi1zeW50YXgtbnMjIj4KICA8cmRmOkRlc2NyaXB0aW9uIHJkZjphYm91dD0iIgogICAgeG1sbnM6ZXhpZj0iaHR0cDovL25zLmFkb2JlLmNvbS9leGlmLzEuMC8iCiAgICB4bWxuczpwaG90b3Nob3A9Imh0dHA6Ly9ucy5hZG9iZS5jb20vcGhvdG9zaG9wLzEuMC8iCiAgICB4bWxuczp0aWZmPSJodHRwOi8vbnMuYWRvYmUuY29tL3RpZmYvMS4wLyIKICAgIHhtbG5zOnhtcD0iaHR0cDovL25zLmFkb2JlLmNvbS94YXAvMS4wLyIKICAgIHhtbG5zOnhtcE1NPSJodHRwOi8vbnMuYWRvYmUuY29tL3hhcC8xLjAvbW0vIgogICAgeG1sbnM6c3RFdnQ9Imh0dHA6Ly9ucy5hZG9iZS5jb20veGFwLzEuMC9zVHlwZS9SZXNvdXJjZUV2ZW50IyIKICAgZXhpZjpDb2xvclNwYWNlPSIxIgogICBleGlmOlBpeGVsWERpbWVuc2lvbj0iMzIiCiAgIGV4aWY6UGl4ZWxZRGltZW5zaW9uPSIzMiIKICAgcGhvdG9zaG9wOkNvbG9yTW9kZT0iMyIKICAgcGhvdG9zaG9wOklDQ1Byb2ZpbGU9InNSR0IgSUVDNjE5NjYtMi4xIgogICB0aWZmOkltYWdlTGVuZ3RoPSIzMiIKICAgdGlmZjpJbWFnZVdpZHRoPSIzMiIKICAgdGlmZjpSZXNvbHV0aW9uVW5pdD0iMiIKICAgdGlmZjpYUmVzb2x1dGlvbj0iNzIvMSIKICAgdGlmZjpZUmVzb2x1dGlvbj0iNzIvMSIKICAgeG1wOk1ldGFkYXRhRGF0ZT0iMjAyNS0wOC0xOFQxMjo0MTo0MyswMjowMCIKICAgeG1wOk1vZGlmeURhdGU9IjIwMjUtMDgtMThUMTI6NDE6NDMrMDI6MDAiPgogICA8eG1wTU06SGlzdG9yeT4KICAgIDxyZGY6U2VxPgogICAgIDxyZGY6bGkKICAgICAgeG1wTU06YWN0aW9uPSJwcm9kdWNlZCIKICAgICAgeG1wTU06c29mdHdhcmVBZ2VudD0iQWZmaW5pdHkgRGVzaWduZXIgMS4xMC41IgogICAgICB4bXBNTTp3aGVuPSIyMDIyLTA4LTExVDEwOjU5OjI5KzAyOjAwIi8+CiAgICAgPHJkZjpsaQogICAgICB4bXBNTTphY3Rpb249InByb2R1Y2VkIgogICAgICB4bXBNTTpzb2Z0d2FyZUFnZW50PSJBZmZpbml0eSBQaG90byAxLjEwLjUiCiAgICAgIHhtcE1NOndoZW49IjIwMjItMDgtMTFUMTU6MDc6MDMrMDI6MDAiLz4KICAgICA8cmRmOmxpCiAgICAgIHN0RXZ0OmFjdGlvbj0icHJvZHVjZWQiCiAgICAgIHN0RXZ0OnNvZnR3YXJlQWdlbnQ9IkFmZmluaXR5IFBob3RvIDIgMi42LjMiCiAgICAgIHN0RXZ0OndoZW49IjIwMjUtMDgtMThUMTI6NDE6NDMrMDI6MDAiLz4KICAgIDwvcmRmOlNlcT4KICAgPC94bXBNTTpIaXN0b3J5PgogIDwvcmRmOkRlc2NyaXB0aW9uPgogPC9yZGY6UkRGPgo8L3g6eG1wbWV0YT4KPD94cGFja2V0IGVuZD0iciI/PvZnu+8AAAGCaUNDUHNSR0IgSUVDNjE5NjYtMi4xAAAokXWRzytEURTHPzOIxmiEhYXFpCGLGTFqsFFm0lCTpjHKr83MMz/U/Hi9N9Jkq2wVJTZ+LfgL2CprpYiUrNkSG/ScZ9RMMud27vnc773ndO+5YI1mlKxe2wfZXEGLBP3Omdk5Z/0zDbRgo4fBmKKro+FwiKr2fovFjNces1b1c/9a42JCV8DSIDyiqFpBeFw4tFJQTd4SblPSsUXhE2G3JhcUvjH1eImfTE6V+NNkLRoJgLVZ2Jmq4HgFK2ktKywvx5XNLCu/9zFfYk/kpqckdop3oBMhiB8nE4wRwEc/wzL78OClV1ZUye/7yZ8kL7mKzCpFNJZIkaaAW9RlqZ6QmBQ9ISND0ez/377qyQFvqbrdD3WPhvHaBfWb8LVhGB8HhvF1CDUPcJ4r5+f3YehN9I2y5toDxxqcXpS1+DacrUP7vRrTYj9Sjbg1mYSXY2iahdYrsM2Xeva7z9EdRFflqy5hZxe65bxj4Ruejmf/iAWTSgAAAAlwSFlzAAALEwAACxMBAJqcGAAAAmxJREFUWIXtlt+LTVEUxz9z75Dp5ncuZcp48uuBFA/Kg19RyqPhYfDkR8xfoIaUSPJChJKm/MqDvMjPJ7pJYe4TKYQYZcyYGt0rcx0P+5xa1l3rnFNe76pd9+z92eu79rp77b2hZS371+YAZ4FB4BcwAlSAdf/ptwd4AdSAH8AdoEtDJeADEBltHFiTIlAGNsRtrhrb6Ph8CRQluMwBk3bdEd8O/BZcA9gvxg+k+NwmHbUBZ1Lgu4b4LMLfpNkBwUwFvjg+TxYEGMXRnnZW+tHoOwhMM/rfiN+jwEXHZ6lgdFYduKK+u4C9DntefT9yuIlWZz/NqWoQKiSLi4Dnhs+yw17Q4ATguwE+VtzyOCjLabezUos9rsEtDihT3QY8cbh3QLsRQIfD92jwpgHVgBmC2ek4i4BeQxxggcH+ATolNB2oG+BVwcwGhhzxUcJhZtkOg3+qoT2O4/WCuZWyer3zpd0w+KYKqhjQeyAp1d0p4hGwyhEv05zZYWCKhBY5Tg/F4ysIe8ETHxKBajtq8H0aOmFADWAe4XL5lLH6+454J/BTsZ/16ovYZ/UDwjlezRCPgMuGeAG4Z7BbNbjWcdpLOIBk31fgmcH2GwEcMbgrVpqs9EfAW/U9BqwErhmsvD/agWMG8wqV+sRuOwHIVgc2xfwph7lE2FyvjbFBjBdQYg8zxGvAZsF35whYb7rFnnhWBkaA1YovEeo4j/gAMD9NHGCfM7kKLHTmeKdm0sYJD5uOLHEI5XKOcDlEwDfgMDApY94umst3jHB3LM0jDOFqTWwmMJlw6DRyzi8CSwhvw2HCTq/nFW9ZywD+Al9yhORsjkEmAAAAAElFTkSuQmCC`;
 
-const uploadAssetHelper = async (page, testAsset) => {
+const uploadAssetHelper = async (page, testAsset, searchable = false) => {
 	const fileChooserPromise = page.waitForFileChooser();
 
-	await page.evaluate(() => {
+	await page.evaluate((searchable) => {
 		window.testAssetUploaded = false;
 		window.webstrate.uploadAsset(() => {
 			window.testAssetUploaded = true;
-		});
-	});
+		}, { searchable });
+	}, searchable);
 
 	const fileChooser = await fileChooserPromise;
 	await fileChooser.accept([testAsset]);
@@ -41,7 +41,7 @@ describe.only('Assets', function () {
 
 	let browserA, browserB, pageA, pageB;
 	let testDir;
-	let testAssetsFs = [];
+	let testTextFile, testCsvFile, testImageFile, testZipFile;
 
 	before(async () => {
 		browserA = await puppeteer.launch();
@@ -58,24 +58,21 @@ describe.only('Assets', function () {
 		}
 
 		// Create a simple text file
-		const textFile = path.join(testDir, 'test.txt');
-		fs.writeFileSync(textFile, textFileContent);
-		testAssetsFs.push(textFile);
+		testTextFile = path.join(testDir, 'test.txt');
+		fs.writeFileSync(testTextFile, textFileContent);
 
 		// Create a simple CSV file for searchable assets
-		const csvFile = path.join(testDir, 'test.csv');
-		fs.writeFileSync(csvFile, 'name,age,city\nJohn,25,New York\nJane,30,Los Angeles\nBob,35,Chicago');
-		testAssetsFs.push(csvFile);
+		testCsvFile = path.join(testDir, 'test.csv');
+		fs.writeFileSync(testCsvFile, 'name,age,city\nJohn,25,New York\nJane,30,Los Angeles\nBob,35,Chicago');
 
 		// Create an image file
-		const imageFile = path.join(testDir, 'test.png');
-		fs.writeFileSync(imageFile, Buffer.from(IMAGE_DATA.split(',')[1], 'base64'));
-		testAssetsFs.push(imageFile);
+		testImageFile = path.join(testDir, 'test.png');
+		fs.writeFileSync(testImageFile, Buffer.from(IMAGE_DATA.split(',')[1], 'base64'));
 
 		// Create a simple ZIP with the above files
-		const zipFile = path.join(testDir, 'test.zip');
+		testZipFile = path.join(testDir, 'test.zip');
 		await new Promise((resolve, reject) => {
-			const output = fs.createWriteStream(zipFile);
+			const output = fs.createWriteStream(testZipFile);
 			const archive = archiver('zip');
 
 			output.on('close', () => {
@@ -87,17 +84,16 @@ describe.only('Assets', function () {
 
 			// Add files to the archive
 			archive.pipe(output);
-			archive.file(textFile, { name: 'test.txt' });
-			archive.file(csvFile, { name: 'test.csv' });
-			archive.file(imageFile, { name: 'test.png' });
+			archive.file(testTextFile, { name: 'test.txt' });
+			archive.file(testCsvFile, { name: 'test.csv' });
+			archive.file(testImageFile, { name: 'test.png' });
 			archive.finalize();
 		});
-		testAssetsFs.push(zipFile);
 	});
 
 	after(async () => {
 		// Clean up test files
-		testAssetsFs.forEach(file => {
+		[testTextFile, testCsvFile, testImageFile, testZipFile].forEach(file => {
 			if (fs.existsSync(file)) {
 				fs.unlinkSync(file);
 			}
@@ -112,7 +108,7 @@ describe.only('Assets', function () {
 	});
 
 	it('Users should be able to upload assets using the API', async () => {
-		await uploadAssetHelper(pageA, testAssetsFs[0]);
+		await uploadAssetHelper(pageA, testTextFile);
 
 		const assets = await pageA.evaluate(async () => {
 			return await window.webstrate.assets;
@@ -137,9 +133,9 @@ describe.only('Assets', function () {
 	it('All assets should be listed in the API and HTTP API', async () => {
 		await pageA.goto(urlA, { waitUntil: 'networkidle2' });
 
-		await uploadAssetHelper(pageA, testAssetsFs[1]);
-		await uploadAssetHelper(pageA, testAssetsFs[2]);
-		await uploadAssetHelper(pageA, testAssetsFs[3]);
+		await uploadAssetHelper(pageA, testCsvFile, true);
+		await uploadAssetHelper(pageA, testImageFile);
+		await uploadAssetHelper(pageA, testZipFile);
 
 		let assetsAPI = await pageA.evaluate(async () => {
 			return await window.webstrate.assets;
@@ -163,7 +159,7 @@ describe.only('Assets', function () {
 	it('The same asset should have the same identifier across different webstrates', async () => {
 		await pageA.goto(urlA, { waitUntil: 'networkidle2' });
 
-		await uploadAssetHelper(pageB, testAssetsFs[0]);
+		await uploadAssetHelper(pageB, testTextFile);
 
 		const textFileAssetA = await pageA.evaluate(() => {
 			return window.webstrate.assets.find(asset => asset.fileName === 'test.txt');

--- a/tests/functional-tests/4-dom-stress-test.mjs
+++ b/tests/functional-tests/4-dom-stress-test.mjs
@@ -5,7 +5,7 @@ import { assert } from 'chai';
 import config from '../config.js';
 import util from '../util.js';
 
-describe('DOM Stress Test', function() {
+describe.only('DOM Stress Test', function() {
 	this.timeout(30000);
 
 	const webstrateId = 'test-' + util.randomString();
@@ -23,9 +23,11 @@ describe('DOM Stress Test', function() {
 		]);
 
 		pageA = pages[0];
-
-		await Promise.all(pages.map(page =>
-			page.goto(url, { waitUntil: 'networkidle2' })));
+		
+		// Connect pages sequentially to prevent "document was created remotely" errors
+		for (let i = 0; i < pages.length; i++) {
+			await pages[i].goto(url, { waitUntil: 'networkidle2' });
+		}
 
 		await Promise.all(pages.map(page =>
 			util.waitForFunction(page, () =>

--- a/tests/functional-tests/4-dom-stress-test.mjs
+++ b/tests/functional-tests/4-dom-stress-test.mjs
@@ -5,7 +5,7 @@ import { assert } from 'chai';
 import config from '../config.js';
 import util from '../util.js';
 
-describe.only('DOM Stress Test', function() {
+describe('DOM Stress Test', function() {
 	this.timeout(30000);
 
 	const webstrateId = 'test-' + util.randomString();


### PR DESCRIPTION
**General Assets**

* Asset metadata is now cleaned up before being returned by removing internal fields such as `_id` and `webstrateId` in `getAssets`.
* When adding assets, the code now properly announces and returns a new asset including a `searchable` flag for searchable CSVs and without `_id` and `webstrateId` fields.

**Seachable CSV Assets**

* Fixed the `csvtojson` conversion errors that prevented CSVs from being parsed.
* Also filtered out internal fields from the CSV asset metadata upon searching.

**Tests**

* Added a test for logging out users to `2-login.mjs`.
* Added a series of tests for assets including ZIP files and searchable CSV files in `3-assets.mjs`.
* Added a test for the HTTP API of invites in `4-invites.mjs`.

**Other**

* Added VS Code config to `.gitignore`.
* Fixed the order in which a snapshot is loaded in the `HttpRequestController.js` where if the invite is accepted, it would use the old snapshot instead of the new one with updated permissions.